### PR TITLE
feat: metadata persistence, feature editor alias/description, folder-…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ node_modules/
 # dotenv environment variables file
 .env
 .env.*
+
+# Domain model explorer / feature editor persisted files (example app working directory)
+DomainModeling.Example/metadata/
+DomainModeling.Example/features/

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Text.Json;
+using System.Text;
 
 namespace DomainModeling.AspNetCore;
 
@@ -40,6 +41,12 @@ public sealed class DomainModelOptions
     /// Defaults to <c>./features</c> relative to the application root.
     /// </summary>
     public string FeatureStoragePath { get; set; } = "./features";
+
+    /// <summary>
+    /// Directory path where domain type alias/description metadata is stored.
+    /// Defaults to <c>./metadata</c> relative to the application root.
+    /// </summary>
+    public string MetadataStoragePath { get; set; } = "./metadata";
 
     /// <summary>
     /// Configuration for the aggregate testing feature.
@@ -147,8 +154,31 @@ public static class DomainModelEndpointExtensions
         // Cache the JSON — mutable so it can be updated when developer view saves
         var json = graph.ToJson();
 
-        // Custom metadata store (alias / description per type)
+        // Custom metadata store (alias / description per type) persisted as JSON files on disk
+        var metadataDir = Path.GetFullPath(options.MetadataStoragePath);
         var metadata = new System.Collections.Concurrent.ConcurrentDictionary<string, TypeMetadata>();
+        if (Directory.Exists(metadataDir))
+        {
+            foreach (var file in Directory.GetFiles(metadataDir, "*.json"))
+            {
+                var fileName = Path.GetFileNameWithoutExtension(file);
+                if (!TryDecodeMetadataFileName(fileName, out var fullName))
+                    continue;
+
+                var content = File.ReadAllText(file);
+                var entry = JsonSerializer.Deserialize<TypeMetadata>(content, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                });
+                if (entry is null)
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(entry.Alias) && string.IsNullOrWhiteSpace(entry.Description))
+                    continue;
+
+                metadata[fullName] = entry;
+            }
+        }
 
         var assetsPrefix = $"{routePrefix}/assets";
 
@@ -206,10 +236,27 @@ public static class DomainModelEndpointExtensions
             if (entry is null)
                 return Results.BadRequest("Invalid metadata");
 
+            var safeFileName = EncodeMetadataFileName(fullName);
+            var path = Path.Combine(metadataDir, safeFileName + ".json");
+
             if (string.IsNullOrWhiteSpace(entry.Alias) && string.IsNullOrWhiteSpace(entry.Description))
+            {
                 metadata.TryRemove(fullName, out _);
+                if (File.Exists(path)) File.Delete(path);
+            }
             else
+            {
                 metadata[fullName] = entry;
+                Directory.CreateDirectory(metadataDir);
+
+                var toWrite = JsonSerializer.Serialize(entry, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+                });
+                await File.WriteAllTextAsync(path, toWrite);
+            }
 
             return Results.Ok(new { saved = true });
         })
@@ -351,14 +398,15 @@ public static class DomainModelEndpointExtensions
         {
             var featureDir = Path.GetFullPath(options.FeatureStoragePath);
 
-            // GET /domain-model/features — list all saved features
+            // GET /domain-model/features — list all saved features (folder per feature)
             endpoints.MapGet($"{routePrefix}/features", () =>
             {
                 if (!Directory.Exists(featureDir))
                     return Results.Json(Array.Empty<object>());
 
-                var features = Directory.GetFiles(featureDir, "*.json")
-                    .Select(f => Path.GetFileNameWithoutExtension(f))
+                var features = Directory.GetDirectories(featureDir)
+                    .Select(d => Path.GetFileName(d))
+                    .Where(n => SanitizeFileName(n) == n && File.Exists(Path.Combine(featureDir, n, "feature.json")))
                     .OrderBy(n => n)
                     .ToArray();
                 return Results.Json(features);
@@ -371,7 +419,7 @@ public static class DomainModelEndpointExtensions
             {
                 var safeName = SanitizeFileName(name);
                 if (safeName is null) return Results.BadRequest("Invalid feature name");
-                var path = Path.Combine(featureDir, safeName + ".json");
+                var path = Path.Combine(featureDir, safeName, "feature.json");
                 if (!File.Exists(path))
                     return Results.NotFound();
                 var content = File.ReadAllText(path);
@@ -393,8 +441,9 @@ public static class DomainModelEndpointExtensions
                 try { using var doc = JsonDocument.Parse(body); }
                 catch (JsonException) { return Results.BadRequest("Invalid JSON"); }
 
-                Directory.CreateDirectory(featureDir);
-                var path = Path.Combine(featureDir, safeName + ".json");
+                var featureFolder = Path.Combine(featureDir, safeName);
+                Directory.CreateDirectory(featureFolder);
+                var path = Path.Combine(featureFolder, "feature.json");
                 await File.WriteAllTextAsync(path, body);
                 return Results.Ok(new { saved = true });
             })
@@ -406,10 +455,10 @@ public static class DomainModelEndpointExtensions
             {
                 var safeName = SanitizeFileName(name);
                 if (safeName is null) return Results.BadRequest("Invalid feature name");
-                var path = Path.Combine(featureDir, safeName + ".json");
-                if (!File.Exists(path))
+                var featureFolder = Path.Combine(featureDir, safeName);
+                if (!Directory.Exists(featureFolder))
                     return Results.NotFound();
-                File.Delete(path);
+                Directory.Delete(featureFolder, recursive: true);
                 return Results.Ok(new { deleted = true });
             })
             .ExcludeFromDescription()
@@ -435,7 +484,7 @@ public static class DomainModelEndpointExtensions
                     if (export is null)
                         return Results.NotFound();
 
-                    var path = Path.Combine(featureDir, safeName + ".json");
+                    var path = Path.Combine(featureDir, safeName, "feature.json");
                     if (!File.Exists(path))
                         return Results.NotFound();
 
@@ -554,5 +603,33 @@ public static class DomainModelEndpointExtensions
         if (sanitized.Contains("..") || sanitized.Contains('/') || sanitized.Contains('\\'))
             return null;
         return sanitized;
+    }
+
+    private static string EncodeMetadataFileName(string fullName)
+    {
+        // Human-readable but reversible. This keeps most namespace characters (including '.')
+        // and percent-encodes characters that are invalid in file names (e.g. '<', '>', spaces).
+        return Uri.EscapeDataString(fullName);
+    }
+
+    private static bool TryDecodeMetadataFileName(string fileName, out string fullName)
+    {
+        fullName = string.Empty;
+        try
+        {
+            var unescaped = Uri.UnescapeDataString(fileName);
+
+            // Guard against false positives: ensure round-trip matches the input.
+            var escapedCheck = Uri.EscapeDataString(unescaped);
+            if (!string.Equals(escapedCheck, fileName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            fullName = unescaped;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 }

--- a/DomainModeling.AspNetCore/FeatureGraph.cs
+++ b/DomainModeling.AspNetCore/FeatureGraph.cs
@@ -62,6 +62,7 @@ public sealed class FeatureEntity
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -72,6 +73,7 @@ public sealed class FeatureEntity
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -84,6 +86,7 @@ public sealed class FeatureAggregate
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -96,6 +99,7 @@ public sealed class FeatureAggregate
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -110,6 +114,7 @@ public sealed class FeatureValueObject
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -119,6 +124,7 @@ public sealed class FeatureValueObject
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -130,6 +136,7 @@ public sealed class FeatureDomainEvent
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -141,6 +148,7 @@ public sealed class FeatureDomainEvent
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -154,6 +162,7 @@ public sealed class FeatureHandler
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -163,6 +172,7 @@ public sealed class FeatureHandler
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -174,6 +184,7 @@ public sealed class FeatureRepository
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -183,6 +194,7 @@ public sealed class FeatureRepository
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -194,6 +206,7 @@ public sealed class FeatureDomainService
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public bool IsCustom { get; init; }
@@ -202,6 +215,7 @@ public sealed class FeatureDomainService
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         IsCustom = n.IsCustom,
@@ -212,6 +226,7 @@ public sealed class FeatureSubType
 {
     public string Name { get; init; } = "";
     public string FullName { get; init; } = "";
+    public string? Alias { get; init; }
     public string? Description { get; init; }
     public string? Layer { get; init; }
     public List<FeatureProperty> Properties { get; init; } = [];
@@ -220,6 +235,7 @@ public sealed class FeatureSubType
     {
         Name = n.Name,
         FullName = n.FullName,
+        Alias = n.Alias,
         Description = n.Description,
         Layer = n.Layer,
         Properties = n.Properties.Select(FeatureProperty.FromGraphProperty).ToList(),

--- a/DomainModeling.AspNetCore/FeatureJsonConverter.cs
+++ b/DomainModeling.AspNetCore/FeatureJsonConverter.cs
@@ -34,6 +34,8 @@ internal static class FeatureJsonConverter
                 var name = node.GetProperty("name").GetString() ?? "";
                 var kind = node.GetProperty("kind").GetString() ?? "";
                 var isCustom = node.TryGetProperty("isCustom", out var ic) && ic.GetBoolean();
+                var alias = GetOptString(node, "alias");
+                var description = GetOptString(node, "description");
                 var properties = ParseProperties(node);
 
                 switch (kind)
@@ -43,6 +45,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                             Properties = properties,
                             Methods = ParseMethods(node),
@@ -53,6 +57,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                             Properties = properties,
                         });
@@ -62,6 +68,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                             Properties = properties,
                         });
@@ -71,6 +79,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                             Properties = properties,
                         });
@@ -80,6 +90,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                             Properties = properties,
                         });
@@ -89,6 +101,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                         });
                         break;
@@ -97,6 +111,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                         });
                         break;
@@ -105,6 +121,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                         });
                         break;
@@ -113,6 +131,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                         });
                         break;
@@ -121,6 +141,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             IsCustom = isCustom,
                         });
                         break;
@@ -129,6 +151,8 @@ internal static class FeatureJsonConverter
                         {
                             Name = name,
                             FullName = id,
+                            Alias = alias,
+                            Description = description,
                             Properties = properties,
                         });
                         break;
@@ -178,6 +202,13 @@ internal static class FeatureJsonConverter
         }
 
         return new DomainGraph(ctx);
+    }
+
+    private static string? GetOptString(JsonElement node, string propName)
+    {
+        if (!node.TryGetProperty(propName, out var el)) return null;
+        var s = el.GetString();
+        return string.IsNullOrWhiteSpace(s) ? null : s.Trim();
     }
 
     private static List<Graph.PropertyInfo> ParseProperties(JsonElement node)

--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -8,6 +8,7 @@ const STORAGE_KEY = 'domain-model-diagram-positions';
 const HIDDEN_KINDS_KEY = 'domain-model-diagram-hidden-kinds';
 const HIDDEN_EDGE_KINDS_KEY = 'domain-model-diagram-hidden-edge-kinds';
 const VIEWPORT_KEY = 'domain-model-diagram-viewport';
+const SHOW_ALIASES_KEY = 'domain-model-diagram-show-aliases';
 const SHOW_LAYERS_KEY = 'domain-model-diagram-show-layers';
 
 const EDGE_CFG = {
@@ -183,6 +184,10 @@ function nodeHeight(n) {
   if (n.events.length > 0) h += DIVIDER_H + n.events.length * PROP_H;
   return h + PAD;
 }
+
+try {
+  showAliases = localStorage.getItem(SHOW_ALIASES_KEY) === 'true';
+} catch { /* ignore */ }
 
 try {
   showLayers = localStorage.getItem(SHOW_LAYERS_KEY) === 'true';
@@ -876,6 +881,7 @@ export function diagramDownloadSvg() {
 
 export function diagramToggleAliases() {
   showAliases = !showAliases;
+  try { localStorage.setItem(SHOW_ALIASES_KEY, showAliases ? 'true' : 'false'); } catch { /* ignore */ }
   const btn = document.getElementById('diagramAliasToggle');
   if (btn) btn.style.background = showAliases ? 'var(--bg-hover)' : '';
   if (dgState) {

--- a/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
@@ -235,6 +235,16 @@ function renderPropertiesPanel() {
     h += `<div class="fe-panel-field"><label>Name</label><div class="fe-panel-value">${esc(n.name)}</div></div>`;
     h += `<div class="fe-panel-field"><label>Full Name</label><div class="fe-panel-value">${esc(n.id)}</div></div>`;
 
+    // Alias (editable)
+    h += `<div class="fe-panel-field"><label>Alias</label>`;
+    h += `<input type="text" class="fe-input" value="${escAttr(n.alias || '')}" placeholder="Display name override…" `;
+    h += `onchange="window.__featureEditor.changeAlias('${escAttr(n.id)}', this.value)" /></div>`;
+
+    // Description (editable)
+    h += `<div class="fe-panel-field"><label>Description</label>`;
+    h += `<textarea class="fe-input" rows="3" placeholder="Custom description…" `;
+    h += `onchange="window.__featureEditor.changeDescription('${escAttr(n.id)}', this.value)">${esc(n.description || '')}</textarea></div>`;
+
     // Bounded Context
     h += `<div class="fe-panel-field"><label>Bounded Context</label>`;
     h += renderBoundedContextDropdown(n);
@@ -482,6 +492,7 @@ function serializeFeature() {
   return {
     nodes: st.nodes.map(n => ({
       id: n.id, name: n.name, kind: n.kind, isCustom: n.isCustom || false,
+      alias: n.alias || null, description: n.description || null,
       boundedContext: n.boundedContext || '', layer: n.layer || '',
       props: n.props, structuredProps: n.structuredProps || [],
       methods: n.methods, events: n.events,
@@ -509,6 +520,8 @@ function loadFeatureState(feature) {
       name: saved.name,
       kind: saved.kind,
       isCustom: saved.isCustom || false,
+      alias: saved.alias || null,
+      description: saved.description || null,
       boundedContext: saved.boundedContext || '',
       layer: saved.layer || '',
       cfg,
@@ -547,19 +560,32 @@ function loadFeatureState(feature) {
 
 // ── Adding types ─────────────────────────────────────
 
+/** Alias / description saved in the main explorer (GET /domain-model/metadata), not per-feature. */
+function getGlobalTypeMetadata(fullName) {
+  const meta = (typeof window !== 'undefined' && window.__metadata) ? window.__metadata[fullName] : null;
+  if (!meta) return { alias: null, description: null };
+  const alias = meta.alias && String(meta.alias).trim() ? String(meta.alias).trim() : null;
+  const description = meta.description && String(meta.description).trim() ? String(meta.description).trim() : null;
+  return { alias, description };
+}
+
 export function addExistingType(fullName, kind) {
   if (!st) return;
   if (st.nMap[fullName]) return; // already added
 
   // Find the item in domain data to get properties etc.
   const item = findDomainItem(fullName, kind);
+  const globalMeta = getGlobalTypeMetadata(fullName);
 
-  const cfg = KIND_CFG[kind];
+    const cfg = KIND_CFG[kind];
   const n = {
     id: fullName,
     name: item ? item.name : shortName(fullName),
     kind,
     isCustom: false,
+    alias: globalMeta.alias,
+    // Custom description from explorer metadata wins over XML doc from discovery
+    description: globalMeta.description || (item && item.description) || null,
     boundedContext: findDomainContext(fullName) || '',
     layer: (item && item.layer) || '',
     cfg,
@@ -605,6 +631,8 @@ export function addNewType() {
     name,
     kind,
     isCustom: true,
+    alias: null,
+    description: null,
     boundedContext: '',
     layer: '',
     cfg,
@@ -779,6 +807,25 @@ function renderBoundedContextDropdown(node) {
   }
   h += '</div></div>';
   return h;
+}
+
+export function changeAlias(nodeId, value) {
+  if (!st) return;
+  const n = st.nMap[nodeId];
+  if (!n) return;
+  n.alias = (value && value.trim()) ? value.trim() : null;
+  markDirty();
+  renderSvg();
+  refreshPanel();
+}
+
+export function changeDescription(nodeId, value) {
+  if (!st) return;
+  const n = st.nMap[nodeId];
+  if (!n) return;
+  n.description = (value && value.trim()) ? value.trim() : null;
+  markDirty();
+  refreshPanel();
 }
 
 export function changeBoundedContext(nodeId, ctxName) {
@@ -1139,7 +1186,8 @@ function renderSvg() {
     let ty = 20;
     s += `<text x="${n.w / 2}" y="${ty}" text-anchor="middle" fill="${c.color}" font-size="10" font-family="-apple-system,sans-serif" opacity="0.85">${c.stereotype}</text>`;
     ty += 22;
-    s += `<text class="fe-name" x="${n.w / 2}" y="${ty}" text-anchor="middle" fill="#f0f2f7" font-size="14" font-weight="600" font-family="-apple-system,sans-serif">${esc(n.name)}</text>`;
+    const displayName = (n.alias && n.alias.trim()) ? n.alias.trim() : n.name;
+    s += `<text class="fe-name" x="${n.w / 2}" y="${ty}" text-anchor="middle" fill="#f0f2f7" font-size="14" font-weight="600" font-family="-apple-system,sans-serif">${esc(displayName)}</text>`;
     if (n.props.length > 0) {
       ty += 8;
       s += `<line x1="12" y1="${ty}" x2="${n.w - 12}" y2="${ty}" stroke="${c.border}" stroke-width="0.5" />`;

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -17,6 +17,7 @@ let featureEditorModule = null; // lazy-loaded when feature editor mode is on
 let metadata = {};
 
 const STORAGE_KEY = 'domainModelSelectedContexts';
+// Legacy browser persistence key (migration-only).
 const METADATA_STORAGE_KEY = 'domainModelMetadata';
 
 let data = null;
@@ -45,19 +46,42 @@ async function init() {
     const res = await fetch(API_URL);
     data = await res.json();
 
-    // Load custom metadata: localStorage first, then merge from server
+    // One-time migration: browser localStorage -> server disk folder.
+    // We only migrate entries that don't yet exist on the server to avoid overwriting.
+    let legacyMetadata = {};
     try {
       const stored = localStorage.getItem(METADATA_STORAGE_KEY);
-      if (stored) metadata = JSON.parse(stored);
+      if (stored) legacyMetadata = JSON.parse(stored);
     } catch { /* ignore corrupt data */ }
+
     try {
       const metaRes = await fetch(`${BASE_URL}/metadata`);
+      let serverMeta = {};
       if (metaRes.ok) {
-        const serverMeta = await metaRes.json();
-        metadata = { ...metadata, ...serverMeta };
-        localStorage.setItem(METADATA_STORAGE_KEY, JSON.stringify(metadata));
+        serverMeta = await metaRes.json();
       }
-    } catch { /* metadata endpoint optional */ }
+
+      metadata = { ...legacyMetadata, ...serverMeta };
+
+      const keysToMigrate = Object.keys(legacyMetadata || {})
+        .filter((k) => !serverMeta || !serverMeta[k]);
+
+      if (keysToMigrate.length > 0) {
+        await Promise.allSettled(keysToMigrate.map(async (fullName) => {
+          const entry = legacyMetadata[fullName];
+          return fetch(`${BASE_URL}/metadata/${encodeURIComponent(fullName)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(entry),
+          });
+        }));
+
+        try { localStorage.removeItem(METADATA_STORAGE_KEY); } catch { /* ignore */ }
+      }
+    } catch { /* metadata endpoint optional */ 
+      // If the server metadata endpoint is unreachable, fall back to legacy localStorage for display.
+      metadata = legacyMetadata;
+    }
     window.__metadata = metadata;
 
     // Load available exports
@@ -287,20 +311,17 @@ function renderMain() {
 async function saveMetadata(fullName, alias, description) {
   const entry = { alias: alias || null, description: description || null };
 
-  // Always update local state and localStorage
+  // Always update local state (server persistence is handled via PUT)
   if ((!alias || !alias.trim()) && (!description || !description.trim())) {
     delete metadata[fullName];
   } else {
     metadata[fullName] = entry;
   }
   window.__metadata = metadata;
-  try {
-    localStorage.setItem(METADATA_STORAGE_KEY, JSON.stringify(metadata));
-  } catch { /* quota exceeded or private mode */ }
 
   // Best-effort sync to server
   try {
-    await fetch(`${BASE_URL}/metadata/${fullName}`, {
+    await fetch(`${BASE_URL}/metadata/${encodeURIComponent(fullName)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(entry),
@@ -417,6 +438,8 @@ function wireFeatureEditorGlobals() {
     removeProperty: featureEditorModule.removeProperty,
     downloadExport: featureEditorModule.downloadExport,
     toggleRelDropdown: featureEditorModule.toggleRelDropdown,
+    changeAlias: featureEditorModule.changeAlias,
+    changeDescription: featureEditorModule.changeDescription,
     changeBoundedContext: featureEditorModule.changeBoundedContext,
     toggleBcDropdown: featureEditorModule.toggleBcDropdown,
     changeLayer: featureEditorModule.changeLayer,

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -71,17 +71,41 @@ app.MapDomainModel(domainGraph, configure: opts =>
         {
             lines.Add($"# {ctx.Name}");
             foreach (var a in ctx.Aggregates)
-                lines.Add($"- **Aggregate**: {a.Name}{(a.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(a.Alias) ? a.Alias : a.Name;
+                var desc = !string.IsNullOrWhiteSpace(a.Description) ? $" — {a.Description}" : "";
+                lines.Add($"- **Aggregate**: {displayName}{desc}{(a.IsCustom ? " *(new)*" : "")}");
+            }
             foreach (var e in ctx.Entities)
-                lines.Add($"- **Entity**: {e.Name}{(e.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(e.Alias) ? e.Alias : e.Name;
+                var desc = !string.IsNullOrWhiteSpace(e.Description) ? $" — {e.Description}" : "";
+                lines.Add($"- **Entity**: {displayName}{desc}{(e.IsCustom ? " *(new)*" : "")}");
+            }
             foreach (var v in ctx.ValueObjects)
-                lines.Add($"- **Value Object**: {v.Name}{(v.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(v.Alias) ? v.Alias : v.Name;
+                var desc = !string.IsNullOrWhiteSpace(v.Description) ? $" — {v.Description}" : "";
+                lines.Add($"- **Value Object**: {displayName}{desc}{(v.IsCustom ? " *(new)*" : "")}");
+            }
             foreach (var ev in ctx.DomainEvents)
-                lines.Add($"- **Event**: {ev.Name}{(ev.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(ev.Alias) ? ev.Alias : ev.Name;
+                var desc = !string.IsNullOrWhiteSpace(ev.Description) ? $" — {ev.Description}" : "";
+                lines.Add($"- **Event**: {displayName}{desc}{(ev.IsCustom ? " *(new)*" : "")}");
+            }
             foreach (var h in ctx.EventHandlers)
-                lines.Add($"- **Handler**: {h.Name}{(h.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(h.Alias) ? h.Alias : h.Name;
+                var desc = !string.IsNullOrWhiteSpace(h.Description) ? $" — {h.Description}" : "";
+                lines.Add($"- **Handler**: {displayName}{desc}{(h.IsCustom ? " *(new)*" : "")}");
+            }
             foreach (var h in ctx.CommandHandlers)
-                lines.Add($"- **Handler**: {h.Name}{(h.IsCustom ? " *(new)*" : "")}");
+            {
+                var displayName = !string.IsNullOrWhiteSpace(h.Alias) ? h.Alias : h.Name;
+                var desc = !string.IsNullOrWhiteSpace(h.Description) ? $" — {h.Description}" : "";
+                lines.Add($"- **Handler**: {displayName}{desc}{(h.IsCustom ? " *(new)*" : "")}");
+            }
             lines.Add("");
         }
         return string.Join(Environment.NewLine, lines);

--- a/DomainModeling/Graph/DomainGraph.cs
+++ b/DomainModeling/Graph/DomainGraph.cs
@@ -62,6 +62,9 @@ public sealed class EntityNode
     public required string Name { get; init; }
     public required string FullName { get; init; }
 
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
+
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
 
@@ -84,6 +87,9 @@ public sealed class AggregateNode
 {
     public required string Name { get; init; }
     public required string FullName { get; init; }
+
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
 
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
@@ -108,6 +114,9 @@ public sealed class ValueObjectNode
     public required string Name { get; init; }
     public required string FullName { get; init; }
 
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
+
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
 
@@ -127,6 +136,9 @@ public sealed class DomainEventNode
 {
     public required string Name { get; init; }
     public required string FullName { get; init; }
+
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
 
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
@@ -154,6 +166,9 @@ public sealed class HandlerNode
     public required string Name { get; init; }
     public required string FullName { get; init; }
 
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
+
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
 
@@ -174,6 +189,9 @@ public sealed class RepositoryNode
 {
     public required string Name { get; init; }
     public required string FullName { get; init; }
+
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
 
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
@@ -196,6 +214,9 @@ public sealed class DomainServiceNode
     public required string Name { get; init; }
     public required string FullName { get; init; }
 
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
+
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }
 
@@ -214,6 +235,9 @@ public sealed class SubTypeNode
 {
     public required string Name { get; init; }
     public required string FullName { get; init; }
+
+    /// <summary>Display name override (alias) set in the feature editor.</summary>
+    public string? Alias { get; set; }
 
     /// <summary>Friendly description from XML documentation comments.</summary>
     public string? Description { get; set; }


### PR DESCRIPTION
…per-feature

- Persist type alias/description to disk under MetadataStoragePath (percent-encoded filenames)
- Diagram: persist show-aliases toggle in localStorage
- Main explorer: migrate legacy localStorage metadata to server; encode fullName in PUT URLs
- Feature storage: one folder per feature with feature.json (avoids cross-feature conflicts)
- DomainGraph + FeatureGraph: Alias on nodes; FeatureJsonConverter + exports use alias/description
- Feature editor: editable alias/description; canvas shows alias; prefill from global metadata when adding types
- Ignore DomainModeling.Example/metadata and features runtime folders

Made-with: Cursor