### PR TITLE
TypeConventionBuilder And/Or branch composition (#16)

### DIFF
--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -425,13 +425,105 @@ public class DDDBuilderTests
                 .WithDomainAssembly(assembly)
                 .DomainEvents(e => e
                     .InheritsFrom<BaseDomainEvent>()
-                    .NameEndsWith("Event") // both rules; any match qualifies
+                    .NameEndsWith("Event") // separate OR branches; any branch qualifies
                 )
             )
             .Build();
 
         var ctx = graph.BoundedContexts.Single();
         ctx.DomainEvents.Should().HaveCountGreaterThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void Build_EventHandlers_AndConvention_RequiresAllPredicatesInBranch()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var graph = DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .EventHandlers(h => h
+                    .Implements(typeof(IEventHandler<>))
+                    .And()
+                    .NameEndsWith("Handler")))
+            .Build();
+
+        var ctx = graph.BoundedContexts.Single();
+        ctx.EventHandlers.Should().HaveCount(2);
+        ctx.EventHandlers.Should().Contain(h => h.Name == "OrderPlacedHandler");
+        ctx.EventHandlers.Should().Contain(h => h.Name == "SendShipmentNotificationHandler");
+        ctx.EventHandlers.Should().NotContain(h => h.Name == "OrderPlacedIntegrationHandler");
+        ctx.EventHandlers.Should().NotContain(h => h.Name.Contains("PublishCustomerRegistered"));
+    }
+
+    [Fact]
+    public void Build_EventHandlers_OrBranches_WithAndGroup_MatchesUnion()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var graph = DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .EventHandlers(h => h
+                    .Implements(typeof(IEventHandler<>))
+                    .And()
+                    .NameEndsWith("Handler")
+                    .Implements(typeof(IIntegrationEventHandler<>))))
+            .Build();
+
+        var ctx = graph.BoundedContexts.Single();
+        ctx.EventHandlers.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TypeConventionBuilder_And_WithoutPriorRule_Throws()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var act = () => DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .EventHandlers(h => h.And()))
+            .Build();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*follow a convention rule*");
+    }
+
+    [Fact]
+    public void TypeConventionBuilder_DanglingAnd_ThrowsOnMatch()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var act = () => DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .EventHandlers(h => h
+                    .Implements(typeof(IEventHandler<>))
+                    .And()))
+            .Build();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*follow the last And()*");
+    }
+
+    [Fact]
+    public void TypeConventionBuilder_DoubleAnd_Throws()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var act = () => DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .EventHandlers(h => h
+                    .Implements(typeof(IEventHandler<>))
+                    .And()
+                    .And()
+                    .NameEndsWith("Handler")))
+            .Build();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*before And()*");
     }
 
     [Fact]

--- a/DomainModeling/Builder/TypeConventionBuilder.cs
+++ b/DomainModeling/Builder/TypeConventionBuilder.cs
@@ -5,11 +5,56 @@ namespace DomainModeling.Builder;
 /// <summary>
 /// Fluent builder to define how a particular DDD building block is identified
 /// in a target project — by base type, implemented interface, naming convention, or attribute.
-/// Multiple rules can be combined; a type matches if it satisfies <b>any</b> of them.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Each convention call (e.g. <see cref="Implements{T}"/>, <see cref="NameEndsWith"/>)
+/// starts a new <b>OR</b> branch: a type matches if it satisfies <b>any</b> branch.
+/// </para>
+/// <para>
+/// Use <see cref="And"/> before the next rule to <b>AND</b> it with the previous branch instead
+/// (e.g. <c>NameEndsWith("Command").And().Implements(typeof(IMyCommand))</c>).
+/// </para>
+/// <para>
+/// Optional <see cref="Or"/> clears a pending <see cref="And"/> and documents intent when
+/// chaining several alternatives.
+/// </para>
+/// </remarks>
 public sealed class TypeConventionBuilder
 {
-    internal List<Func<Type, bool>> Predicates { get; } = [];
+    private readonly List<List<Func<Type, bool>>> _orBranches = [];
+    private bool _mergeNextIntoCurrentBranch;
+
+    /// <summary>
+    /// True when at least one convention rule has been configured.
+    /// </summary>
+    internal bool HasPredicates => _orBranches.Count > 0;
+
+    /// <summary>
+    /// AND the next rule with the current branch (the one formed by the immediately preceding rule).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No prior rule exists, or <see cref="And"/> was already called without a following rule.</exception>
+    public TypeConventionBuilder And()
+    {
+        if (_mergeNextIntoCurrentBranch)
+            throw new InvalidOperationException("A convention rule must follow And() before And() can be used again.");
+
+        if (_orBranches.Count == 0)
+            throw new InvalidOperationException("And() must follow a convention rule such as NameEndsWith or Implements.");
+
+        _mergeNextIntoCurrentBranch = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Starts the next rule as a new OR branch. Usually unnecessary because each rule already begins
+    /// a new branch; use this to cancel a pending <see cref="And"/> or to clarify intent.
+    /// </summary>
+    public TypeConventionBuilder Or()
+    {
+        _mergeNextIntoCurrentBranch = false;
+        return this;
+    }
 
     /// <summary>
     /// Match types that inherit (directly or indirectly) from <typeparamref name="T"/>.
@@ -17,7 +62,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder InheritsFrom<T>()
     {
         var baseType = typeof(T);
-        Predicates.Add(t => IsAssignableToGenericOrConcrete(t, baseType) && t != baseType);
+        AddPredicate(t => IsAssignableToGenericOrConcrete(t, baseType) && t != baseType);
         return this;
     }
 
@@ -27,7 +72,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder InheritsFrom(Type baseType)
     {
         ArgumentNullException.ThrowIfNull(baseType);
-        Predicates.Add(t => IsAssignableToGenericOrConcrete(t, baseType) && t != baseType);
+        AddPredicate(t => IsAssignableToGenericOrConcrete(t, baseType) && t != baseType);
         return this;
     }
 
@@ -37,7 +82,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder Implements<T>()
     {
         var interfaceType = typeof(T);
-        Predicates.Add(t => IsAssignableToGenericOrConcrete(t, interfaceType) && t != interfaceType);
+        AddPredicate(t => IsAssignableToGenericOrConcrete(t, interfaceType) && t != interfaceType);
         return this;
     }
 
@@ -47,7 +92,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder Implements(Type interfaceType)
     {
         ArgumentNullException.ThrowIfNull(interfaceType);
-        Predicates.Add(t => IsAssignableToGenericOrConcrete(t, interfaceType) && t != interfaceType);
+        AddPredicate(t => IsAssignableToGenericOrConcrete(t, interfaceType) && t != interfaceType);
         return this;
     }
 
@@ -57,7 +102,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder NameEndsWith(string suffix)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
-        Predicates.Add(t => t.Name.EndsWith(suffix, StringComparison.Ordinal));
+        AddPredicate(t => t.Name.EndsWith(suffix, StringComparison.Ordinal));
         return this;
     }
 
@@ -68,7 +113,7 @@ public sealed class TypeConventionBuilder
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(regexPattern);
         var regex = new Regex(regexPattern, RegexOptions.Compiled);
-        Predicates.Add(t => regex.IsMatch(t.Name));
+        AddPredicate(t => regex.IsMatch(t.Name));
         return this;
     }
 
@@ -77,7 +122,7 @@ public sealed class TypeConventionBuilder
     /// </summary>
     public TypeConventionBuilder HasAttribute<TAttribute>() where TAttribute : Attribute
     {
-        Predicates.Add(t => t.GetCustomAttributes(typeof(TAttribute), true).Length > 0);
+        AddPredicate(t => t.GetCustomAttributes(typeof(TAttribute), true).Length > 0);
         return this;
     }
 
@@ -87,7 +132,7 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder HasAttribute(Type attributeType)
     {
         ArgumentNullException.ThrowIfNull(attributeType);
-        Predicates.Add(t => t.GetCustomAttributes(attributeType, true).Length > 0);
+        AddPredicate(t => t.GetCustomAttributes(attributeType, true).Length > 0);
         return this;
     }
 
@@ -97,14 +142,31 @@ public sealed class TypeConventionBuilder
     public TypeConventionBuilder Where(Func<Type, bool> predicate)
     {
         ArgumentNullException.ThrowIfNull(predicate);
-        Predicates.Add(predicate);
+        AddPredicate(predicate);
         return this;
     }
 
     /// <summary>
-    /// Returns true if the given type matches <b>any</b> of the configured predicates.
+    /// Returns true if the type matches any OR branch, where each branch requires all of its predicates (AND).
     /// </summary>
-    internal bool Matches(Type type) => Predicates.Count > 0 && Predicates.Any(p => p(type));
+    internal bool Matches(Type type)
+    {
+        if (_mergeNextIntoCurrentBranch)
+            throw new InvalidOperationException("A convention rule must follow the last And().");
+
+        return _orBranches.Count > 0 && _orBranches.Any(branch => branch.All(p => p(type)));
+    }
+
+    private void AddPredicate(Func<Type, bool> predicate)
+    {
+        if (_mergeNextIntoCurrentBranch)
+        {
+            _orBranches[^1].Add(predicate);
+            _mergeNextIntoCurrentBranch = false;
+        }
+        else
+            _orBranches.Add([predicate]);
+    }
 
     /// <summary>
     /// Handles both concrete and open-generic base type / interface matching.

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -521,7 +521,7 @@ internal sealed class AssemblyScanner
         List<DomainServiceNode> domainServiceNodes,
         List<CommandHandlerTargetNode> commandHandlerTargetNodes)
     {
-        if (_config.CommandConvention.Predicates.Count == 0)
+        if (!_config.CommandConvention.HasPredicates)
             return;
 
         var excluded = CollectPrimaryBuildingBlockFullNames(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #16](https://github.com/rubenvanderpol/NetDomainModeling/issues/16): the fluent convention API now supports **AND** within a branch while keeping **OR** between separate rules (e.g. multiple `Implements(...)` calls).

## Behavior

- Each convention call (`Implements`, `NameEndsWith`, etc.) starts a new **OR** branch unless it follows `And()`.
- `And()` merges the **next** rule into the same branch as the previous rule, so all predicates in that branch must pass (logical AND).
- `Or()` clears a pending `And()` and can be used to clarify intent; separate calls already imply OR.

Example from the issue:

```csharp
// OR between handler interfaces (unchanged)
h => h
    .Implements(typeof(IEventHandler<>))
    .Implements(typeof(IIntegrationEventHandler<>))

// AND: name suffix and interface
a => a.NameEndsWith("Command").And().Implements(typeof(IMyMarker))
```

## Implementation notes

- Replaced the flat `Predicates` list with internal OR-branch storage and `HasPredicates` for the command merge check in `AssemblyScanner`.
- `Matches` evaluates `any(branch => branch.All(predicate))`.
- Invalid sequences (`And()` first, `And()` twice without a rule in between, or a trailing `And()`) throw `InvalidOperationException` with explicit messages.

## Tests

- `dotnet test`: 52 passed (new coverage for AND filtering, `(A && B) || C`, and error cases).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd5b2942-06b7-4179-b754-d82234f5795f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd5b2942-06b7-4179-b754-d82234f5795f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

