### PR TITLE
Add StorageRootPath for domain model persisted files

### DIFF
--- a/DomainModeling.AspNetCore/DiagramLayoutModels.cs
+++ b/DomainModeling.AspNetCore/DiagramLayoutModels.cs
@@ -4,7 +4,8 @@ namespace DomainModeling.AspNetCore;
 
 /// <summary>
 /// Persisted main diagram layout (single document for the explorer diagram).
-/// Stored as <c>diagram-layout.json</c> under <see cref="DomainModelOptions.DiagramLayoutStoragePath"/>.
+/// Stored as <c>diagram-layout.json</c> under <see cref="DomainModelOptions.DiagramLayoutStoragePath"/>
+/// (resolved with <see cref="DomainModelOptions.StorageRootPath"/> when set).
 /// </summary>
 internal sealed class DiagramLayoutDocument
 {

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -45,20 +45,29 @@ public sealed class DomainModelOptions
     public bool EnableTraceView { get; set; }
 
     /// <summary>
+    /// Optional base directory for all persisted explorer files (diagram positions, type alias/description
+    /// metadata, and feature editor data). When set, <see cref="DiagramLayoutStoragePath"/>,
+    /// <see cref="MetadataStoragePath"/>, and <see cref="FeatureStoragePath"/> are resolved as paths
+    /// relative to this root unless they are already absolute. When null or whitespace, each storage path
+    /// is resolved on its own (defaults remain relative to the process current directory).
+    /// </summary>
+    public string? StorageRootPath { get; set; }
+
+    /// <summary>
     /// Directory path where feature editor JSON files are stored.
-    /// Defaults to <c>./features</c> relative to the application root.
+    /// Defaults to <c>./features</c>. Relative paths are under <see cref="StorageRootPath"/> when it is set.
     /// </summary>
     public string FeatureStoragePath { get; set; } = "./features";
 
     /// <summary>
     /// Directory path where domain type alias/description metadata is stored.
-    /// Defaults to <c>./metadata</c> relative to the application root.
+    /// Defaults to <c>./metadata</c>. Relative paths are under <see cref="StorageRootPath"/> when it is set.
     /// </summary>
     public string MetadataStoragePath { get; set; } = "./metadata";
 
     /// <summary>
     /// Directory path where the main diagram layout file <c>diagram-layout.json</c> is stored.
-    /// Defaults to <c>./diagram-layout</c> relative to the application root.
+    /// Defaults to <c>./diagram-layout</c>. Relative paths are under <see cref="StorageRootPath"/> when it is set.
     /// </summary>
     public string DiagramLayoutStoragePath { get; set; } = "./diagram-layout";
 
@@ -173,12 +182,12 @@ public static class DomainModelEndpointExtensions
         var json = graph.ToJson();
 
         // Main diagram layout — single JSON file under this directory
-        var diagramLayoutDir = Path.GetFullPath(options.DiagramLayoutStoragePath);
+        var diagramLayoutDir = DomainModelStoragePathResolver.Resolve(options.StorageRootPath, options.DiagramLayoutStoragePath);
         const string diagramLayoutFileName = "diagram-layout.json";
         var diagramLayoutFilePath = Path.Combine(diagramLayoutDir, diagramLayoutFileName);
 
         // Custom metadata store (alias / description per type) persisted as JSON files on disk
-        var metadataDir = Path.GetFullPath(options.MetadataStoragePath);
+        var metadataDir = DomainModelStoragePathResolver.Resolve(options.StorageRootPath, options.MetadataStoragePath);
         var metadata = new System.Collections.Concurrent.ConcurrentDictionary<string, TypeMetadata>();
         if (Directory.Exists(metadataDir))
         {
@@ -497,7 +506,7 @@ public static class DomainModelEndpointExtensions
         // Feature editor endpoints
         if (options.EnableFeatureEditor)
         {
-            var featureDir = Path.GetFullPath(options.FeatureStoragePath);
+            var featureDir = DomainModelStoragePathResolver.Resolve(options.StorageRootPath, options.FeatureStoragePath);
 
             // GET /domain-model/features — list all saved features (folder per feature)
             endpoints.MapGet($"{routePrefix}/features", () =>

--- a/DomainModeling.AspNetCore/DomainModelStoragePathResolver.cs
+++ b/DomainModeling.AspNetCore/DomainModelStoragePathResolver.cs
@@ -1,0 +1,30 @@
+namespace DomainModeling.AspNetCore;
+
+/// <summary>
+/// Resolves persisted storage directories for the domain model explorer.
+/// When <paramref name="storageRoot"/> is set, relative <paramref name="path"/> values
+/// are resolved under that root; absolute <paramref name="path"/> values are unchanged.
+/// </summary>
+internal static class DomainModelStoragePathResolver
+{
+    /// <summary>
+    /// Returns a full directory path for storage.
+    /// </summary>
+    /// <param name="storageRoot">Optional base directory; null or whitespace means <paramref name="path"/> is resolved alone (current behavior).</param>
+    /// <param name="path">Directory path, typically a default like <c>./metadata</c> or a custom relative/absolute path.</param>
+    public static string Resolve(string? storageRoot, string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var trimmedPath = path.Trim();
+
+        if (string.IsNullOrWhiteSpace(storageRoot))
+            return Path.GetFullPath(trimmedPath);
+
+        var trimmedRoot = storageRoot.Trim();
+        if (Path.IsPathRooted(trimmedPath))
+            return Path.GetFullPath(trimmedPath);
+
+        var rootFull = Path.GetFullPath(trimmedRoot);
+        return Path.GetFullPath(Path.Combine(rootFull, trimmedPath));
+    }
+}

--- a/DomainModeling.Tests/DomainModelStoragePathResolverTests.cs
+++ b/DomainModeling.Tests/DomainModelStoragePathResolverTests.cs
@@ -1,0 +1,54 @@
+using DomainModeling.AspNetCore;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public sealed class DomainModelStoragePathResolverTests
+{
+    [Fact]
+    public void Resolve_without_root_full_paths_relative_path_against_current_directory()
+    {
+        var result = DomainModelStoragePathResolver.Resolve(null, "./metadata");
+        result.Should().Be(Path.GetFullPath("./metadata"));
+    }
+
+    [Fact]
+    public void Resolve_without_root_treats_empty_root_as_absent()
+    {
+        var result = DomainModelStoragePathResolver.Resolve("   ", "./diagram-layout");
+        result.Should().Be(Path.GetFullPath("./diagram-layout"));
+    }
+
+    [Fact]
+    public void Resolve_with_root_joins_relative_storage_path()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "dm-root-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var result = DomainModelStoragePathResolver.Resolve(root, "./metadata");
+            result.Should().Be(Path.GetFullPath(Path.Combine(root, "metadata")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_with_root_leaves_absolute_storage_path_unchanged()
+    {
+        var absolute = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "abs-meta"));
+        var root = Path.Combine(Path.GetTempPath(), "ignored-root");
+        var result = DomainModelStoragePathResolver.Resolve(root, absolute);
+        result.Should().Be(absolute);
+    }
+
+    [Fact]
+    public void Resolve_throws_when_path_is_empty()
+    {
+        var act = () => DomainModelStoragePathResolver.Resolve("/tmp", "  ");
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `DomainModelOptions.StorageRootPath` so diagram layout (node positions), type metadata (alias/description JSON files), and feature editor storage can resolve under one base directory. Relative `DiagramLayoutStoragePath`, `MetadataStoragePath`, and `FeatureStoragePath` values are combined with the root; absolute storage paths are left as-is.

## Details

- New internal `DomainModelStoragePathResolver` centralizes resolution.
- Unit tests cover root absent, root set, absolute override, and invalid path.

Closes https://github.com/rubenvanderpol/NetDomainModeling/issues/39
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d016c7bd-1007-4dae-8eba-875cd0b1ee68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d016c7bd-1007-4dae-8eba-875cd0b1ee68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

