### PR TITLE
fix: merge saved diagram layout when types are added or removed

### DIFF
--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -560,17 +560,27 @@ export function initDiagram(ctx, boundedContexts) {
       posSource = 'local';
     }
 
+    /** Node ids whose x/y were restored from the saved layout (server or local). */
+    let appliedFromSaved = null;
     let hasSaved = false;
+    let hasPartialSaved = false;
     if (saved) {
-      let allFound = true;
+      appliedFromSaved = new Set();
       for (const n of nodes) {
-        if (saved[n.id]) { n.x = saved[n.id].x; n.y = saved[n.id].y; }
-        else { allFound = false; }
+        const p = saved[n.id];
+        if (p && typeof p.x === 'number' && typeof p.y === 'number') {
+          n.x = p.x;
+          n.y = p.y;
+          appliedFromSaved.add(n.id);
+        }
       }
-      hasSaved = allFound;
+      hasSaved = nodes.length > 0 && appliedFromSaved.size === nodes.length;
+      hasPartialSaved = nodes.length > 0 && appliedFromSaved.size > 0 && appliedFromSaved.size < nodes.length;
     }
 
-    if (!hasSaved) {
+    if (hasPartialSaved) {
+      applyAutoLayout(nodes, edges, nMap, appliedFromSaved);
+    } else if (!hasSaved) {
       applyAutoLayout(nodes, edges, nMap);
     }
 
@@ -606,14 +616,14 @@ export function initDiagram(ctx, boundedContexts) {
 
     const lsViewport = loadViewport();
     let savedViewport = null;
-    if (hasSaved) {
+    if (hasSaved || hasPartialSaved) {
       if (serverLayout?.viewport && typeof serverLayout.viewport.zoom === 'number') {
         savedViewport = serverLayout.viewport;
       } else {
         savedViewport = lsViewport;
       }
     }
-    if (hasSaved && savedViewport) {
+    if ((hasSaved || hasPartialSaved) && savedViewport) {
       dgState.zoom = savedViewport.zoom;
       dgState.panX = savedViewport.panX;
       dgState.panY = savedViewport.panY;
@@ -623,7 +633,7 @@ export function initDiagram(ctx, boundedContexts) {
     refreshDiagramKindFilters();
     syncDiagramToolbarToggles();
 
-    if (!hasSaved || !savedViewport) {
+    if ((!hasSaved && !hasPartialSaved) || !savedViewport) {
       fitToView();
       saveViewport(dgState.zoom, dgState.panX, dgState.panY);
     }
@@ -798,10 +808,15 @@ function applyDiagramVisibility() {
 }
 
 // ── Auto-layout (row-based + forces) ─────────────────
-function applyAutoLayout(nodes, edges, nMap) {
-  // Group nodes by bounded context for initial placement
+/** @param {Set<string>|null|undefined} fixedNodeIds If set, those nodes keep their current x/y (partial layout restore). */
+function applyAutoLayout(nodes, edges, nMap, fixedNodeIds) {
+  const fixed = fixedNodeIds instanceof Set && fixedNodeIds.size > 0 ? fixedNodeIds : null;
+  const isFixed = (n) => fixed && fixed.has(n.id);
+
+  // Group movable nodes by bounded context for initial placement
   const ctxGroups = {};
   for (const n of nodes) {
+    if (isFixed(n)) continue;
     const key = n.contextName || '__default';
     (ctxGroups[key] = ctxGroups[key] || []).push(n);
   }
@@ -827,19 +842,25 @@ function applyAutoLayout(nodes, edges, nMap) {
     }
   } else {
     const rowBuckets = {};
-    for (const n of nodes) { const r = kindRow[n.kind] || 0; (rowBuckets[r] = rowBuckets[r] || []).push(n); }
+    for (const n of nodes) {
+      if (isFixed(n)) continue;
+      const r = kindRow[n.kind] || 0;
+      (rowBuckets[r] = rowBuckets[r] || []).push(n);
+    }
     for (const [row, rNodes] of Object.entries(rowBuckets)) {
       const y = parseInt(row) * 240;
       rNodes.forEach((n, i) => { n.x = (i - (rNodes.length - 1) / 2) * 270; n.y = y; });
     }
   }
 
-  // Force simulation
+  // Force simulation (fixed nodes participate in forces but do not move)
   for (let i = 0; i < 150; i++) {
     const alpha = 1 - i / 150;
     for (let a = 0; a < nodes.length; a++) {
       for (let b = a + 1; b < nodes.length; b++) {
         const na = nodes[a], nb = nodes[b];
+        const fa = isFixed(na), fb = isFixed(nb);
+        if (fa && fb) continue;
         let dx = nb.x - na.x, dy = nb.y - na.y;
         const dist = Math.sqrt(dx * dx + dy * dy) || 1;
         // Stronger repulsion between nodes of different contexts
@@ -847,19 +868,24 @@ function applyAutoLayout(nodes, edges, nMap) {
         const repStrength = crossCtx ? 16000 : 8000;
         const force = (repStrength * alpha) / (dist * dist);
         const fx = (dx / dist) * force, fy = (dy / dist) * force;
-        na.vx -= fx; na.vy -= fy; nb.vx += fx; nb.vy += fy;
+        if (!fa) { na.vx -= fx; na.vy -= fy; }
+        if (!fb) { nb.vx += fx; nb.vy += fy; }
       }
     }
     for (const e of edges) {
       const s = nMap[e.source], t = nMap[e.target];
       if (!s || !t) continue;
+      const fs = isFixed(s), ft = isFixed(t);
+      if (fs && ft) continue;
       const dx = t.x - s.x, dy = t.y - s.y;
       const dist = Math.sqrt(dx * dx + dy * dy) || 1;
       const force = dist * 0.004 * alpha;
       const fx = (dx / dist) * force, fy = (dy / dist) * force;
-      s.vx += fx; s.vy += fy; t.vx -= fx; t.vy -= fy;
+      if (!fs) { s.vx += fx; s.vy += fy; }
+      if (!ft) { t.vx -= fx; t.vy -= fy; }
     }
     for (const n of nodes) {
+      if (isFixed(n)) { n.vx = 0; n.vy = 0; continue; }
       n.vx *= 0.82; n.vy *= 0.82;
       n.x += n.vx; n.y += n.vy;
     }

--- a/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
@@ -973,7 +973,10 @@ function loadFeatureState(feature) {
     n.h = nodeHeight(n);
     // Restore position
     const pos = feature.positions?.[n.id];
-    if (pos) { n.x = pos.x; n.y = pos.y; }
+    if (pos && typeof pos.x === 'number' && typeof pos.y === 'number') {
+      n.x = pos.x;
+      n.y = pos.y;
+    }
     st.nodes.push(n);
     st.nMap[n.id] = n;
   }
@@ -985,10 +988,18 @@ function loadFeatureState(feature) {
     }
   }
 
-  // Auto-layout nodes without positions
-  const needsLayout = st.nodes.filter(n => n.x === 0 && n.y === 0);
-  if (needsLayout.length > 0 && needsLayout.length === st.nodes.length) {
+  const fixedFromSaved = new Set();
+  for (const n of st.nodes) {
+    const pos = feature.positions?.[n.id];
+    if (pos && typeof pos.x === 'number' && typeof pos.y === 'number') {
+      fixedFromSaved.add(n.id);
+    }
+  }
+  const needsLayout = st.nodes.filter(n => !fixedFromSaved.has(n.id));
+  if (needsLayout.length === st.nodes.length) {
     applyAutoLayout(st.nodes, st.edges, st.nMap);
+  } else if (needsLayout.length > 0) {
+    applyAutoLayout(st.nodes, st.edges, st.nMap, fixedFromSaved);
   }
 }
 
@@ -1509,13 +1520,18 @@ function refreshPalette() {
 
 // ── Auto-layout (reused from diagram logic) ──────────
 
-function applyAutoLayout(nodes, edges, nMap) {
+/** @param {Set<string>|null|undefined} fixedNodeIds If set, those nodes keep their current x/y. */
+function applyAutoLayout(nodes, edges, nMap, fixedNodeIds) {
+  const fixed = fixedNodeIds instanceof Set && fixedNodeIds.size > 0 ? fixedNodeIds : null;
+  const isFixed = (n) => fixed && fixed.has(n.id);
+
   const kindRow = {
     aggregate: 0, entity: 1, valueObject: 1, event: 2, integrationEvent: 2,
     eventHandler: 3, commandHandlerTarget: 2, commandHandler: 3, queryHandler: 3, repository: 4, service: 4,
   };
   const rowBuckets = {};
   for (const n of nodes) {
+    if (isFixed(n)) continue;
     const r = kindRow[n.kind] || 0;
     (rowBuckets[r] = rowBuckets[r] || []).push(n);
   }
@@ -1528,23 +1544,32 @@ function applyAutoLayout(nodes, edges, nMap) {
     for (let a = 0; a < nodes.length; a++) {
       for (let b = a + 1; b < nodes.length; b++) {
         const na = nodes[a], nb = nodes[b];
+        const fa = isFixed(na), fb = isFixed(nb);
+        if (fa && fb) continue;
         let dx = nb.x - na.x, dy = nb.y - na.y;
         const dist = Math.sqrt(dx * dx + dy * dy) || 1;
         const force = (8000 * alpha) / (dist * dist);
         const fx = (dx / dist) * force, fy = (dy / dist) * force;
-        na.vx -= fx; na.vy -= fy; nb.vx += fx; nb.vy += fy;
+        if (!fa) { na.vx -= fx; na.vy -= fy; }
+        if (!fb) { nb.vx += fx; nb.vy += fy; }
       }
     }
     for (const e of edges) {
       const s = nMap[e.source], t = nMap[e.target];
       if (!s || !t) continue;
+      const fs = isFixed(s), ft = isFixed(t);
+      if (fs && ft) continue;
       const dx = t.x - s.x, dy = t.y - s.y;
       const dist = Math.sqrt(dx * dx + dy * dy) || 1;
       const force = dist * 0.004 * alpha;
       const fx = (dx / dist) * force, fy = (dy / dist) * force;
-      s.vx += fx; s.vy += fy; t.vx -= fx; t.vy -= fy;
+      if (!fs) { s.vx += fx; s.vy += fy; }
+      if (!ft) { t.vx -= fx; t.vy -= fy; }
     }
-    for (const n of nodes) { n.vx *= 0.82; n.vy *= 0.82; n.x += n.vx; n.y += n.vy; }
+    for (const n of nodes) {
+      if (isFixed(n)) { n.vx = 0; n.vy = 0; continue; }
+      n.vx *= 0.82; n.vy *= 0.82; n.x += n.vx; n.y += n.vy;
+    }
   }
   for (const n of nodes) { n.vx = 0; n.vy = 0; }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes https://github.com/rubenvanderpol/NetDomainModeling/issues/45.

Previously, loading a saved layout required a coordinate for **every** node. If the domain model gained or lost types, the UI discarded the entire saved layout and re-ran full auto-layout.

## Changes
- **`diagram.js`**: Apply all saved positions that still match current nodes. For nodes without entries, run auto-layout with **fixed** nodes (saved coordinates) acting as anchors in the force simulation. Treat partial restores like full restores for viewport when a saved viewport exists.
- **`feature-editor.js`**: When loading a feature, if some nodes have saved positions and others do not, run the same partial auto-layout instead of leaving new nodes at (0,0) or only laying out when *no* positions existed.

## Verification
- `dotnet build`
- `dotnet test` (61 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1160cdf-858e-44d6-b35d-fa841bc9285b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1160cdf-858e-44d6-b35d-fa841bc9285b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

