### PR TITLE
Scaffold: hide types from main diagram (explorer checkboxes)

### DIFF
--- a/DomainModeling.AspNetCore/DiagramLayoutModels.cs
+++ b/DomainModeling.AspNetCore/DiagramLayoutModels.cs
@@ -20,6 +20,12 @@ internal sealed class DiagramLayoutDocument
     [JsonPropertyName("hiddenEdgeKinds")]
     public List<string> HiddenEdgeKinds { get; set; } = [];
 
+    /// <summary>
+    /// Node ids (type full names) hidden individually on the main diagram, in addition to kind/edge filters.
+    /// </summary>
+    [JsonPropertyName("hiddenNodeIds")]
+    public List<string> HiddenNodeIds { get; set; } = [];
+
     [JsonPropertyName("showAliases")]
     public bool? ShowAliases { get; set; }
 

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -262,7 +262,10 @@ public static class DomainModelEndpointExtensions
             var safeFileName = EncodeMetadataFileName(fullName);
             var path = Path.Combine(metadataDir, safeFileName + ".json");
 
-            if (string.IsNullOrWhiteSpace(entry.Alias) && string.IsNullOrWhiteSpace(entry.Description))
+            var hasAlias = !string.IsNullOrWhiteSpace(entry.Alias);
+            var hasDescription = !string.IsNullOrWhiteSpace(entry.Description);
+            var hasDiagramFlag = entry.HiddenOnDiagram.HasValue;
+            if (!hasAlias && !hasDescription && !hasDiagramFlag)
             {
                 metadata.TryRemove(fullName, out _);
                 if (File.Exists(path)) File.Delete(path);

--- a/DomainModeling.AspNetCore/wwwroot/css/explorer.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/explorer.css
@@ -491,6 +491,27 @@ body.feature-editor-view-mode .sidebar-toggle {
   font-style: italic;
 }
 
+.detail-diagram-visibility-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.detail-diagram-visibility-label input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.detail-diagram-visibility-note {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
 .detail-section {
   margin-bottom: 24px;
 }

--- a/DomainModeling.AspNetCore/wwwroot/css/explorer.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/explorer.css
@@ -189,6 +189,37 @@ body {
 .nav-item:hover { background: var(--bg-hover); color: var(--text); }
 .nav-item.active { background: var(--accent-dim); color: var(--accent); }
 
+.nav-item-with-diagram-toggle {
+  padding-left: 8px;
+  gap: 4px;
+}
+
+.nav-diagram-visibility {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 2px;
+  cursor: pointer;
+}
+
+.nav-diagram-visibility input[type="checkbox"] {
+  cursor: pointer;
+  margin: 0;
+}
+
+.nav-diagram-visibility-spacer {
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.nav-item-label {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .nav-dot {
   width: 6px; height: 6px;
   border-radius: 50%;

--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -11,6 +11,7 @@ import { renderTabBar } from './tabs.js';
 // Global layout (not scoped by bounded-context selection)
 const STORAGE_KEY = 'domain-model-diagram-positions-global';
 const HIDDEN_KINDS_KEY = 'domain-model-diagram-hidden-kinds-global';
+const HIDDEN_NODE_IDS_KEY = 'domain-model-diagram-hidden-node-ids-global';
 const HIDDEN_EDGE_KINDS_KEY = 'domain-model-diagram-hidden-edge-kinds-global';
 const VIEWPORT_KEY = 'domain-model-diagram-viewport-global';
 const SHOW_ALIASES_KEY = 'domain-model-diagram-show-aliases';
@@ -149,6 +150,7 @@ function buildLayoutPayloadFromState() {
       panY: Math.round(dgState.panY * 10) / 10,
     },
     hiddenKinds: [...dgState.hiddenKinds],
+    hiddenNodeIds: [...dgState.hiddenNodeIds],
     hiddenEdgeKinds: [...dgState.hiddenEdgeKinds],
     showAliases,
     showLayers,
@@ -225,6 +227,55 @@ export function saveDiagramHiddenKindsSet(hiddenKinds) {
 
 export function saveDiagramHiddenEdgeKindsSet(hiddenEdgeKinds) {
   saveHiddenEdgeKinds(hiddenEdgeKinds instanceof Set ? hiddenEdgeKinds : new Set(hiddenEdgeKinds || []));
+}
+
+function loadHiddenNodeIds() {
+  try {
+    const raw = localStorage.getItem(HIDDEN_NODE_IDS_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch { return new Set(); }
+}
+
+function saveHiddenNodeIds(hiddenNodeIds) {
+  try {
+    localStorage.setItem(HIDDEN_NODE_IDS_KEY, JSON.stringify([...hiddenNodeIds]));
+  } catch { /* quota exceeded or private mode */ }
+  scheduleFlushDiagramLayout();
+}
+
+/** @returns {boolean} */
+export function isDiagramNodeHidden(nodeId) {
+  if (dgState && dgState.hiddenNodeIds) {
+    return dgState.hiddenNodeIds.has(nodeId);
+  }
+  return loadHiddenNodeIds().has(nodeId);
+}
+
+/**
+ * Hide or show a single type on the main diagram (persists with diagram layout).
+ * @param {string} nodeId Full type name (diagram node id).
+ * @param {boolean} hidden When true, the node is hidden (if its kind is visible).
+ */
+export function setDiagramNodeHidden(nodeId, hidden) {
+  if (typeof nodeId !== 'string' || !nodeId) return;
+  if (dgState && dgState.hiddenNodeIds) {
+    if (hidden) dgState.hiddenNodeIds.add(nodeId);
+    else dgState.hiddenNodeIds.delete(nodeId);
+    saveHiddenNodeIds(dgState.hiddenNodeIds);
+    applyDiagramVisibility();
+    renderSvg();
+    syncDiagramKindFilterUi();
+    if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+      window.__onDiagramHiddenNodesChanged();
+    }
+  } else {
+    const set = loadHiddenNodeIds();
+    if (hidden) set.add(nodeId);
+    else set.delete(nodeId);
+    saveHiddenNodeIds(set);
+  }
 }
 
 function loadPositions() {
@@ -632,6 +683,13 @@ export function initDiagram(ctx, boundedContexts) {
       hiddenEdgeKinds = loadHiddenEdgeKinds();
     }
 
+    let hiddenNodeIds;
+    if (serverLayout && Array.isArray(serverLayout.hiddenNodeIds)) {
+      hiddenNodeIds = new Set(serverLayout.hiddenNodeIds.filter((id) => typeof id === 'string'));
+    } else {
+      hiddenNodeIds = loadHiddenNodeIds();
+    }
+
     if (serverLayout && typeof serverLayout.showAliases === 'boolean') {
       showAliases = serverLayout.showAliases;
       try { localStorage.setItem(SHOW_ALIASES_KEY, showAliases ? 'true' : 'false'); } catch { /* ignore */ }
@@ -651,7 +709,7 @@ export function initDiagram(ctx, boundedContexts) {
     dgState = {
       nodes, edges, nMap, allNodes: nodes, allEdges: edges,
       zoom: 1, panX: 0, panY: 0, contextName,
-      hiddenKinds, hiddenEdgeKinds, edgeWaypoints,
+      hiddenKinds, hiddenNodeIds, hiddenEdgeKinds, edgeWaypoints,
     };
     applyDiagramVisibility();
 
@@ -692,6 +750,9 @@ export function initDiagram(ctx, boundedContexts) {
       } catch { /* ignore */ }
       try {
         localStorage.setItem(HIDDEN_EDGE_KINDS_KEY, JSON.stringify([...hiddenEdgeKinds]));
+      } catch { /* ignore */ }
+      try {
+        localStorage.setItem(HIDDEN_NODE_IDS_KEY, JSON.stringify([...hiddenNodeIds]));
       } catch { /* ignore */ }
       try {
         saveEdgeWaypoints(edgeWaypoints);
@@ -843,6 +904,7 @@ function applyDiagramVisibility() {
   const visibleIds = new Set();
   dgState.nodes = dgState.allNodes.filter(n => {
     if (dgState.hiddenKinds.has(n.kind)) return false;
+    if (dgState.hiddenNodeIds.has(n.id)) return false;
     visibleIds.add(n.id);
     return true;
   });
@@ -1401,6 +1463,8 @@ export function diagramResetLayout(ctx) {
   if (!dgState || !ctx) return;
   clearPositions();
   clearViewport();
+  dgState.hiddenNodeIds = new Set();
+  saveHiddenNodeIds(dgState.hiddenNodeIds);
   dgState.edgeWaypoints = {};
   saveEdgeWaypoints(dgState.edgeWaypoints);
   applyAutoLayout(dgState.allNodes, dgState.allEdges, dgState.nMap);
@@ -1409,6 +1473,9 @@ export function diagramResetLayout(ctx) {
   fitToView();
   savePositions(dgState.allNodes);
   saveViewport(dgState.zoom, dgState.panX, dgState.panY);
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
 }
 
 export function diagramToggleKind(eventOrKind, maybeKind) {
@@ -1429,6 +1496,9 @@ export function diagramToggleKind(eventOrKind, maybeKind) {
   applyDiagramVisibility();
   renderSvg();
   syncDiagramKindFilterUi();
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
 }
 
 function setAllKindVisibility(visible) {
@@ -1445,6 +1515,9 @@ function setAllKindVisibility(visible) {
   applyDiagramVisibility();
   renderSvg();
   syncDiagramKindFilterUi();
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
 }
 
 export function diagramShowAllKinds() {
@@ -1458,12 +1531,17 @@ export function diagramHideAllKinds() {
 export function diagramShowAll() {
   if (!dgState) return;
   dgState.hiddenKinds.clear();
+  dgState.hiddenNodeIds.clear();
   dgState.hiddenEdgeKinds.clear();
   saveHiddenKinds(dgState.hiddenKinds);
+  saveHiddenNodeIds(dgState.hiddenNodeIds);
   saveHiddenEdgeKinds(dgState.hiddenEdgeKinds);
   applyDiagramVisibility();
   renderSvg();
   refreshDiagramKindFilters();
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
 }
 
 export function diagramToggleEdgeKind(eventOrKind, maybeKind) {
@@ -1484,6 +1562,9 @@ export function diagramToggleEdgeKind(eventOrKind, maybeKind) {
   applyDiagramVisibility();
   renderSvg();
   refreshDiagramEdgeFilter();
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
 }
 
 function toggleDropdown(menuId, triggerId) {

--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -245,35 +245,55 @@ function saveHiddenNodeIds(hiddenNodeIds) {
   scheduleFlushDiagramLayout();
 }
 
-/** @returns {boolean} */
+/**
+ * Whether custom metadata (alias/description) implies the type should default to hidden on the diagram
+ * until the user opts in with `hiddenOnDiagram: false`.
+ */
+export function metadataImpliesDiagramHiddenByDefault(meta) {
+  if (!meta || typeof meta !== 'object') return false;
+  const a = typeof meta.alias === 'string' ? meta.alias.trim() : '';
+  const d = typeof meta.description === 'string' ? meta.description.trim() : '';
+  return a.length > 0 || d.length > 0;
+}
+
+/**
+ * Effective per-type hide on the main diagram: kind filters are applied separately.
+ * Uses `window.__metadata` for `hiddenOnDiagram` and custom-metadata defaults; merges legacy `hiddenNodeIds` from layout.
+ * @param {string} nodeId
+ * @returns {boolean} true if this node should not appear on the diagram (when its kind is visible).
+ */
 export function isDiagramNodeHidden(nodeId) {
-  if (dgState && dgState.hiddenNodeIds) {
-    return dgState.hiddenNodeIds.has(nodeId);
-  }
+  const meta = (typeof window !== 'undefined' && window.__metadata && window.__metadata[nodeId]) || null;
+  if (meta && meta.hiddenOnDiagram === false) return false;
+  if (meta && meta.hiddenOnDiagram === true) return true;
+  if (metadataImpliesDiagramHiddenByDefault(meta)) return true;
+  if (dgState && dgState.hiddenNodeIds) return dgState.hiddenNodeIds.has(nodeId);
   return loadHiddenNodeIds().has(nodeId);
 }
 
 /**
- * Hide or show a single type on the main diagram (persists with diagram layout).
- * @param {string} nodeId Full type name (diagram node id).
- * @param {boolean} hidden When true, the node is hidden (if its kind is visible).
+ * Re-run visibility after metadata changes (does not reload layout from disk).
  */
-export function setDiagramNodeHidden(nodeId, hidden) {
+export function reapplyDiagramVisibilityAfterMetadataChange() {
+  if (!dgState) return;
+  applyDiagramVisibility();
+  renderSvg();
+  syncDiagramKindFilterUi();
+  if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
+    window.__onDiagramHiddenNodesChanged();
+  }
+}
+
+/** Remove id from legacy per-layout hidden list (superseded by metadata.hiddenOnDiagram). */
+export function removeLegacyHiddenNodeId(nodeId) {
   if (typeof nodeId !== 'string' || !nodeId) return;
-  if (dgState && dgState.hiddenNodeIds) {
-    if (hidden) dgState.hiddenNodeIds.add(nodeId);
-    else dgState.hiddenNodeIds.delete(nodeId);
+  if (dgState && dgState.hiddenNodeIds && dgState.hiddenNodeIds.has(nodeId)) {
+    dgState.hiddenNodeIds.delete(nodeId);
     saveHiddenNodeIds(dgState.hiddenNodeIds);
-    applyDiagramVisibility();
-    renderSvg();
-    syncDiagramKindFilterUi();
-    if (typeof window.__onDiagramHiddenNodesChanged === 'function') {
-      window.__onDiagramHiddenNodesChanged();
-    }
   } else {
     const set = loadHiddenNodeIds();
-    if (hidden) set.add(nodeId);
-    else set.delete(nodeId);
+    if (!set.has(nodeId)) return;
+    set.delete(nodeId);
     saveHiddenNodeIds(set);
   }
 }
@@ -904,7 +924,7 @@ function applyDiagramVisibility() {
   const visibleIds = new Set();
   dgState.nodes = dgState.allNodes.filter(n => {
     if (dgState.hiddenKinds.has(n.kind)) return false;
-    if (dgState.hiddenNodeIds.has(n.id)) return false;
+    if (isDiagramNodeHidden(n.id)) return false;
     visibleIds.add(n.id);
     return true;
   });

--- a/DomainModeling.AspNetCore/wwwroot/js/helpers.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/helpers.js
@@ -140,6 +140,22 @@ export const ALL_SECTIONS = [
   'repositories', 'domainServices'
 ];
 
+/** Maps explorer section keys to main-diagram node `kind` strings (see `diagram.js` KIND_CFG). */
+export const SECTION_TO_DIAGRAM_KIND = {
+  aggregates: 'aggregate',
+  entities: 'entity',
+  valueObjects: 'valueObject',
+  subTypes: 'subType',
+  domainEvents: 'event',
+  integrationEvents: 'integrationEvent',
+  commandHandlerTargets: 'commandHandlerTarget',
+  eventHandlers: 'eventHandler',
+  commandHandlers: 'commandHandler',
+  queryHandlers: 'queryHandler',
+  repositories: 'repository',
+  domainServices: 'service',
+};
+
 /** Section metadata used in sidebar + overview. */
 export const SECTION_META = [
   { key: 'aggregates',           label: 'Aggregates',           color: 'var(--clr-aggregate)',          tag: 'AGG',  bg: 'var(--clr-aggregate-bg)' },

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -3,7 +3,12 @@
  */
 import { esc, escAttr, shortName, ALL_SECTIONS, SECTION_META } from './helpers.js';
 import { renderDetailView } from './views.js';
-import { renderDiagramView, initDiagram, diagramZoom, diagramFit, diagramResetLayout, diagramToggleKind, diagramShowAll, diagramDownloadSvg, diagramToggleAliases, diagramToggleLayers, diagramToggleEdgeKind, diagramToggleEdgeFilter, diagramToggleKindFilter, diagramShowAllKinds, diagramHideAllKinds, setDiagramLayoutBaseUrl, setServerDiagramLayoutCache } from './diagram.js';
+import {
+  renderDiagramView, initDiagram, diagramZoom, diagramFit, diagramResetLayout, diagramToggleKind, diagramShowAll,
+  diagramDownloadSvg, diagramToggleAliases, diagramToggleLayers, diagramToggleEdgeKind, diagramToggleEdgeFilter,
+  diagramToggleKindFilter, diagramShowAllKinds, diagramHideAllKinds, setDiagramLayoutBaseUrl, setServerDiagramLayoutCache,
+  setDiagramNodeHidden, isDiagramNodeHidden, getDiagramState,
+} from './diagram.js';
 
 const API_URL = window.__config?.apiUrl || '/domain-model/json';
 const BASE_URL = API_URL.replace(/\/json$/, '');
@@ -21,6 +26,22 @@ let metadata = {};
 const STORAGE_KEY = 'domainModelSelectedContexts';
 // Legacy browser persistence key (migration-only).
 const METADATA_STORAGE_KEY = 'domainModelMetadata';
+
+/** Maps explorer section keys to diagram node `kind` strings (see `diagram.js` KIND_CFG). */
+const SECTION_TO_DIAGRAM_KIND = {
+  aggregates: 'aggregate',
+  entities: 'entity',
+  valueObjects: 'valueObject',
+  subTypes: 'subType',
+  domainEvents: 'event',
+  integrationEvents: 'integrationEvent',
+  commandHandlerTargets: 'commandHandlerTarget',
+  eventHandlers: 'eventHandler',
+  commandHandlers: 'commandHandler',
+  queryHandlers: 'queryHandler',
+  repositories: 'repository',
+  domainServices: 'service',
+};
 
 let data = null;
 let selectedContextNames = new Set();
@@ -138,6 +159,7 @@ async function init() {
 
     render();
     initSidebarToggle();
+    window.__onDiagramHiddenNodesChanged = syncExplorerDiagramHideCheckboxes;
   } catch (e) {
     document.getElementById('loadingState').textContent = 'Failed to load domain model. Check the console.';
     console.error('Failed to load domain model:', e);
@@ -200,6 +222,7 @@ function render() {
   renderSidebar();
   renderMain();
   syncFeatureEditorViewBodyClass();
+  requestAnimationFrame(() => syncExplorerDiagramHideCheckboxes());
 }
 
 /** Hide explorer sidebar in feature editor view mode so canvas matches Diagram tab width. */
@@ -259,14 +282,26 @@ function renderSidebar() {
         <span class="chevron">▼</span>
       </div>
       <div class="nav-items">
-        ${items.map(item => `
-          <div class="nav-item${isActive(sec.key, item) ? ' active' : ''}"
-               onclick="window.__nav.showDetail('${sec.key}', '${escAttr(item.fullName)}')"
+        ${items.map(item => {
+          const dk = SECTION_TO_DIAGRAM_KIND[sec.key];
+          const hidden = dk && isNavDiagramHidden(dk, item.fullName);
+          const visTitle = hidden
+            ? 'Show on diagram (type may still be hidden via diagram filters)'
+            : 'Hide from diagram';
+          return `
+          <div class="nav-item nav-item-with-diagram-toggle${isActive(sec.key, item) ? ' active' : ''}"
                data-fullname="${escAttr(item.fullName)}">
-            <span class="nav-dot" style="background:${sec.color}"></span>
-            ${esc(item.name)}
-          </div>
-        `).join('')}
+            ${dk ? `<label class="nav-diagram-visibility" title="${escAttr(visTitle)}" onclick="event.stopPropagation()">
+              <input type="checkbox" ${hidden ? '' : 'checked'}
+                     data-nav-kind="${escAttr(sec.key)}"
+                     onchange="window.__nav.toggleDiagramVisibility('${escAttr(item.fullName)}', this.checked)" />
+            </label>` : '<span class="nav-diagram-visibility-spacer"></span>'}
+            <span class="nav-item-label" onclick="window.__nav.showDetail('${sec.key}', '${escAttr(item.fullName)}')">
+              <span class="nav-dot" style="background:${sec.color}"></span>
+              ${esc(item.name)}
+            </span>
+          </div>`;
+        }).join('')}
       </div>
     </div>`;
   }
@@ -308,6 +343,35 @@ function isActive(key, item) {
     return currentDetail.kind === key && currentDetail.item.fullName === item.fullName;
   }
   return false;
+}
+
+function isNavDiagramHidden(diagramKind, fullName) {
+  const st = getDiagramState();
+  if (st && st.hiddenKinds.has(diagramKind)) return true;
+  return isDiagramNodeHidden(fullName);
+}
+
+function syncExplorerDiagramHideCheckboxes() {
+  for (const row of document.querySelectorAll('.nav-item-with-diagram-toggle')) {
+    const fullName = row.getAttribute('data-fullname');
+    const input = row.querySelector('input[type="checkbox"][data-nav-kind]');
+    if (!fullName || !input) continue;
+    const kindKey = input.getAttribute('data-nav-kind');
+    const dk = kindKey ? SECTION_TO_DIAGRAM_KIND[kindKey] : null;
+    if (!dk) continue;
+    const hidden = isNavDiagramHidden(dk, fullName);
+    input.checked = !hidden;
+    const lab = row.querySelector('.nav-diagram-visibility');
+    if (lab) {
+      lab.title = hidden
+        ? 'Show on diagram (type may still be hidden via diagram filters)'
+        : 'Hide from diagram';
+    }
+  }
+}
+
+function toggleDiagramVisibility(fullName, visible) {
+  setDiagramNodeHidden(fullName, !visible);
 }
 
 function renderMain() {
@@ -406,7 +470,9 @@ function toggleSection(el) {
 }
 
 // ── Expose to global scope for onclick handlers ──────
-window.__nav = { switchTab, showDetail, navigateTo, toggleSection, toggleContext };
+window.__nav = {
+  switchTab, showDetail, navigateTo, toggleSection, toggleContext, toggleDiagramVisibility,
+};
 window.__saveMetadata = saveMetadata;
 window.__downloadExport = async function(name) {
   try {

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -1,13 +1,14 @@
 /**
  * Main entry point — wires up data loading, navigation, sidebar, and views.
  */
-import { esc, escAttr, shortName, ALL_SECTIONS, SECTION_META } from './helpers.js';
+import { esc, escAttr, shortName, ALL_SECTIONS, SECTION_META, SECTION_TO_DIAGRAM_KIND } from './helpers.js';
 import { renderDetailView } from './views.js';
 import {
   renderDiagramView, initDiagram, diagramZoom, diagramFit, diagramResetLayout, diagramToggleKind, diagramShowAll,
   diagramDownloadSvg, diagramToggleAliases, diagramToggleLayers, diagramToggleEdgeKind, diagramToggleEdgeFilter,
   diagramToggleKindFilter, diagramShowAllKinds, diagramHideAllKinds, setDiagramLayoutBaseUrl, setServerDiagramLayoutCache,
-  setDiagramNodeHidden, isDiagramNodeHidden, getDiagramState,
+  isDiagramNodeHidden, getDiagramState, metadataImpliesDiagramHiddenByDefault, reapplyDiagramVisibilityAfterMetadataChange,
+  removeLegacyHiddenNodeId,
 } from './diagram.js';
 
 const API_URL = window.__config?.apiUrl || '/domain-model/json';
@@ -26,22 +27,6 @@ let metadata = {};
 const STORAGE_KEY = 'domainModelSelectedContexts';
 // Legacy browser persistence key (migration-only).
 const METADATA_STORAGE_KEY = 'domainModelMetadata';
-
-/** Maps explorer section keys to diagram node `kind` strings (see `diagram.js` KIND_CFG). */
-const SECTION_TO_DIAGRAM_KIND = {
-  aggregates: 'aggregate',
-  entities: 'entity',
-  valueObjects: 'valueObject',
-  subTypes: 'subType',
-  domainEvents: 'event',
-  integrationEvents: 'integrationEvent',
-  commandHandlerTargets: 'commandHandlerTarget',
-  eventHandlers: 'eventHandler',
-  commandHandlers: 'commandHandler',
-  queryHandlers: 'queryHandler',
-  repositories: 'repository',
-  domainServices: 'service',
-};
 
 let data = null;
 let selectedContextNames = new Set();
@@ -286,8 +271,8 @@ function renderSidebar() {
           const dk = SECTION_TO_DIAGRAM_KIND[sec.key];
           const hidden = dk && isNavDiagramHidden(dk, item.fullName);
           const visTitle = hidden
-            ? 'Show on diagram (type may still be hidden via diagram filters)'
-            : 'Hide from diagram';
+            ? 'Show on main diagram'
+            : 'Hide from main diagram';
           return `
           <div class="nav-item nav-item-with-diagram-toggle${isActive(sec.key, item) ? ' active' : ''}"
                data-fullname="${escAttr(item.fullName)}">
@@ -364,14 +349,52 @@ function syncExplorerDiagramHideCheckboxes() {
     const lab = row.querySelector('.nav-diagram-visibility');
     if (lab) {
       lab.title = hidden
-        ? 'Show on diagram (type may still be hidden via diagram filters)'
-        : 'Hide from diagram';
+        ? 'Show on main diagram'
+        : 'Hide from main diagram';
     }
   }
 }
 
-function toggleDiagramVisibility(fullName, visible) {
-  setDiagramNodeHidden(fullName, !visible);
+function metadataEntryIsEmpty(entry) {
+  if (!entry || typeof entry !== 'object') return true;
+  const a = entry.alias && String(entry.alias).trim();
+  const d = entry.description && String(entry.description).trim();
+  if (a || d) return false;
+  if (entry.hiddenOnDiagram === true || entry.hiddenOnDiagram === false) return false;
+  return true;
+}
+
+async function persistMetadata(fullName, entry) {
+  if (metadataEntryIsEmpty(entry)) {
+    delete metadata[fullName];
+  } else {
+    metadata[fullName] = entry;
+  }
+  window.__metadata = metadata;
+
+  try {
+    if (metadataEntryIsEmpty(entry)) {
+      await fetch(`${BASE_URL}/metadata/${encodeURIComponent(fullName)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ alias: null, description: null, hiddenOnDiagram: null }),
+      });
+    } else {
+      await fetch(`${BASE_URL}/metadata/${encodeURIComponent(fullName)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(entry),
+      });
+    }
+  } catch { /* server unreachable */ }
+}
+
+async function toggleDiagramVisibility(fullName, visible) {
+  const prev = metadata[fullName] || {};
+  const next = { ...prev, hiddenOnDiagram: visible ? false : true };
+  removeLegacyHiddenNodeId(fullName);
+  await persistMetadata(fullName, next);
+  reapplyDiagramVisibilityAfterMetadataChange();
 }
 
 function renderMain() {
@@ -415,24 +438,19 @@ function renderMain() {
 // ── Metadata persistence ─────────────────────────────
 
 async function saveMetadata(fullName, alias, description) {
-  const entry = { alias: alias || null, description: description || null };
-
-  // Always update local state (server persistence is handled via PUT)
-  if ((!alias || !alias.trim()) && (!description || !description.trim())) {
-    delete metadata[fullName];
-  } else {
-    metadata[fullName] = entry;
+  const prev = metadata[fullName] || {};
+  const next = {
+    ...prev,
+    alias: alias && String(alias).trim() ? alias : null,
+    description: description && String(description).trim() ? description : null,
+  };
+  if (!metadataImpliesDiagramHiddenByDefault(next)) {
+    delete next.hiddenOnDiagram;
+  } else if (next.hiddenOnDiagram === undefined) {
+    next.hiddenOnDiagram = true;
   }
-  window.__metadata = metadata;
-
-  // Best-effort sync to server
-  try {
-    await fetch(`${BASE_URL}/metadata/${encodeURIComponent(fullName)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(entry),
-    });
-  } catch { /* server unreachable */ }
+  await persistMetadata(fullName, next);
+  reapplyDiagramVisibilityAfterMetadataChange();
 }
 
 // ── Navigation (exposed as window.__nav) ─────────────

--- a/DomainModeling.AspNetCore/wwwroot/js/views.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/views.js
@@ -1,7 +1,10 @@
 /**
  * Overview + Cards + Detail views.
  */
-import { esc, escAttr, shortName, kindMeta, relKindColor, syntaxHighlight, SECTION_META } from './helpers.js';
+import {
+  esc, escAttr, shortName, kindMeta, relKindColor, syntaxHighlight, SECTION_META, SECTION_TO_DIAGRAM_KIND,
+} from './helpers.js';
+import { isDiagramNodeHidden, getDiagramState } from './diagram.js';
 import { renderTabBar } from './tabs.js';
 
 // ── Overview ─────────────────────────────────────────
@@ -122,12 +125,29 @@ function renderCard(item, sec) {
 export function renderDetailView(kind, item, ctx, metadata, saveMetadataFn) {
   const meta = kindMeta(kind);
   const existing = (metadata || {})[item.fullName] || {};
+  const diagramKind = SECTION_TO_DIAGRAM_KIND[kind];
+  const st = getDiagramState();
+  const kindFiltered = diagramKind && st && st.hiddenKinds.has(diagramKind);
+  const perTypeHidden = diagramKind && isDiagramNodeHidden(item.fullName);
+  const diagramHidden = kindFiltered || perTypeHidden;
+  const detailCbDisabled = kindFiltered ? ' disabled' : '';
 
   let html = '<div class="detail-panel">';
   html += `<div class="detail-back" onclick="window.__nav.switchTab('diagram')">← Back to diagram</div>`;
   html += `<div style="margin-bottom:4px"><span class="card-tag" style="color:${meta.color};background:${meta.bg}">${meta.tag}</span></div>`;
   html += `<h2 class="detail-title">${esc(item.name)}</h2>`;
   html += `<div class="detail-fullname">${esc(item.fullName)}</div>`;
+
+  if (diagramKind) {
+    html += `<div class="detail-section detail-diagram-visibility">
+      <label class="detail-diagram-visibility-label">
+        <input type="checkbox" id="detailDiagramVisible"${diagramHidden ? '' : ' checked'}${detailCbDisabled}
+               onchange="window.__nav.toggleDiagramVisibility('${escAttr(item.fullName)}', this.checked)" />
+        <span>Show on main diagram</span>
+      </label>
+      ${kindFiltered ? '<p class="detail-diagram-visibility-note">This node type is hidden via the diagram toolbar; turn the type back on to show this item.</p>' : ''}
+    </div>`;
+  }
 
   if (item.description) {
     html += `<div class="detail-desc">${esc(item.description)}</div>`;

--- a/DomainModeling/Graph/DomainGraph.cs
+++ b/DomainModeling/Graph/DomainGraph.cs
@@ -378,6 +378,11 @@ public sealed class TypeMetadata
 {
     public string? Alias { get; set; }
     public string? Description { get; set; }
+
+    /// <summary>
+    /// When true, the type is hidden on the main diagram (in addition to diagram kind filters).
+    /// </summary>
+    public bool? HiddenOnDiagram { get; set; }
 }
 
 internal static class JsonOptions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements per-type visibility on the main diagram (issue #47) using **custom metadata** plus diagram kind filters.

## Behavior

- **`TypeMetadata.HiddenOnDiagram`** (`true` / `false` / omitted): stored with alias/description in `/domain-model/metadata`. Server keeps JSON files when only this flag is set.
- **Custom types** (alias or description set): default to **hidden on the diagram** (`hiddenOnDiagram: true` on save) until the user checks **Show on main diagram**. Clearing alias/description removes the default-hide behavior unless `hiddenOnDiagram` was explicitly set.
- **Kind filters** (diagram toolbar): if a node kind is hidden, every item of that kind stays off the diagram; the explorer/detail checkbox is disabled with a short note.
- **Legacy** `hiddenNodeIds` in `diagram-layout.json` still applies as a fallback; toggling visibility clears an id from that list when superseded by metadata.

## UI

- Sidebar: checkbox per type (unchanged wiring, new semantics).
- **Detail view**: **Show on main diagram** checkbox when an item is selected.

## Files

- `DomainModeling/Graph/DomainGraph.cs`, `DomainModelEndpointExtensions.cs`
- `wwwroot/js/diagram.js`, `main.js`, `views.js`, `helpers.js`, `explorer.css`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3167280-b9c2-4efc-b705-3f740b7f1402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3167280-b9c2-4efc-b705-3f740b7f1402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

