### PR TITLE
Fix missing links when event handlers create commands or call command handlers (#49)

### DIFF
--- a/DomainModeling.Example/Domain/Handlers.cs
+++ b/DomainModeling.Example/Domain/Handlers.cs
@@ -18,6 +18,22 @@ public class OrderPlacedHandler : IEventHandler<OrderPlacedEvent>
     }
 }
 
+/// <summary>
+/// Example of an event handler that issues another command: the domain explorer shows
+/// <c>Handles</c> edges to the command DTO and <c>References</c> to the command handler (see GitHub #49).
+/// </summary>
+public class ProductPriceChangedHandler : IEventHandler<ProductPriceChangedEvent>
+{
+    private readonly RegisterCustomerCommandHandler _registerCustomer = new();
+
+    public Task HandleAsync(ProductPriceChangedEvent @event, CancellationToken ct = default)
+    {
+        // Illustrative follow-up command (e.g. notify marketing when pricing changes)
+        var cmd = new RegisterCustomerCommand("Price watcher", "pricing@example.com");
+        return _registerCustomer.HandleAsync(cmd, ct);
+    }
+}
+
 public class SendShipmentNotificationHandler : IEventHandler<OrderShippedEvent>
 {
     public Task HandleAsync(OrderShippedEvent @event, CancellationToken ct = default)

--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -106,6 +106,32 @@ public class DDDBuilderTests
             r.TargetType.Contains("PlaceOrderCommand"));
     }
 
+    /// <summary>
+    /// GitHub #49: event handlers that construct command DTOs or call another command handler should surface graph links.
+    /// </summary>
+    [Fact]
+    public void Build_EventHandler_LinksToCommandTarget_AndReferencedCommandHandler()
+    {
+        var graph = BuildSampleGraph();
+        var ctx = graph.BoundedContexts.Single();
+
+        var placeOrderCmd = ctx.CommandHandlerTargets.Single(t => t.Name == "PlaceOrderCommand");
+        placeOrderCmd.HandledBy.Should().Contain(h => h.Contains("OrderPlacedHandler"));
+
+        ctx.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.Handles &&
+            r.SourceType.Contains("OrderPlacedHandler") &&
+            r.TargetType.Contains("PlaceOrderCommand") &&
+            r.Label == "creates command");
+
+        ctx.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.References &&
+            r.SourceType.Contains("OrderPlacedHandler") &&
+            r.TargetType.Contains("PlaceOrderCommandHandler") &&
+            r.Label != null &&
+            r.Label.Contains("HandleAsync", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void Build_CommandsConvention_SurfacesCommandTypesWithoutHandlers()
     {

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -100,6 +100,27 @@ public class ExampleAppGraphTests
             r.Label.Contains("Place", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Build_ProductPriceChangedHandler_LinksToRegisterCustomerCommand_AndHandler()
+    {
+        var graph = BuildExampleGraph();
+        var catalog = graph.BoundedContexts.Single(c => c.Name == "Catalog");
+
+        var target = catalog.CommandHandlerTargets.Single(t => t.Name == "RegisterCustomerCommand");
+        target.HandledBy.Should().Contain(h => h.Contains("ProductPriceChangedHandler", StringComparison.Ordinal));
+
+        catalog.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.Handles &&
+            r.SourceType.Contains("ProductPriceChangedHandler", StringComparison.Ordinal) &&
+            r.TargetType.Contains("RegisterCustomerCommand", StringComparison.Ordinal) &&
+            r.Label == "creates command");
+
+        catalog.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.References &&
+            r.SourceType.Contains("ProductPriceChangedHandler", StringComparison.Ordinal) &&
+            r.TargetType.Contains("RegisterCustomerCommandHandler", StringComparison.Ordinal));
+    }
+
     private static DomainGraph BuildExampleGraph()
     {
         var catalogDomainAssembly = typeof(Product).Assembly;

--- a/DomainModeling.Tests/SampleDomain/SampleTypes.cs
+++ b/DomainModeling.Tests/SampleDomain/SampleTypes.cs
@@ -194,11 +194,15 @@ public sealed class Invoice : BaseAggregateRoot
 
 public class OrderPlacedHandler : IEventHandler<OrderPlacedEvent>
 {
+    private readonly PlaceOrderCommandHandler _followUpCommandHandler = new();
+
     public Task HandleAsync(OrderPlacedEvent @event, CancellationToken ct = default)
     {
         // Publish integration event
         var integrationEvent = new OrderPlacedIntegrationEvent { OrderId = @event.OrderId };
-        return Task.CompletedTask;
+        // Issue #49: event handler creates a command and may delegate to another command handler
+        _ = new PlaceOrderCommand(Guid.Empty, []);
+        return _followUpCommandHandler.HandleAsync(new PlaceOrderCommand(@event.OrderId, []), ct);
     }
 }
 

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -120,7 +120,6 @@ internal sealed class AssemblyScanner
             repositoryNodes,
             domainServiceNodes,
             commandHandlerTargetNodes);
-        CrossReferenceCommandHandlerTargets(commandHandlerTargetNodes, commandHandlerNodes);
 
         // Build relationships
         var relationships = new List<Relationship>();
@@ -225,6 +224,45 @@ internal sealed class AssemblyScanner
                 });
             }
         }
+
+        // EventHandler → command DTO / command handler (IL scan; GitHub #49)
+        var commandTargetFullNames = new HashSet<string>(
+            commandHandlerTargetNodes.Select(t => t.FullName),
+            StringComparer.Ordinal);
+        var commandHandlerFullNames = new HashSet<string>(
+            commandHandlerNodes.Select(h => h.FullName),
+            StringComparer.Ordinal);
+        var commandTargetMap = commandHandlerTargetNodes.ToDictionary(t => t.FullName, StringComparer.Ordinal);
+        foreach (var handlerType in eventHandlerTypes)
+        {
+            var source = handlerType.FullName!;
+            foreach (var cmdFullName in DetectInstantiatedTypes(handlerType, commandTargetFullNames))
+            {
+                relationships.Add(new Relationship
+                {
+                    SourceType = source,
+                    TargetType = cmdFullName,
+                    Kind = RelationshipKind.Handles,
+                    Label = "creates command"
+                });
+                if (commandTargetMap.TryGetValue(cmdFullName, out var targetNode) &&
+                    !targetNode.HandledBy.Contains(source))
+                    targetNode.HandledBy.Add(source);
+            }
+
+            foreach (var (targetFullName, methodName) in DetectInvocationsOnDeclaredTypes(handlerType, commandHandlerFullNames))
+            {
+                relationships.Add(new Relationship
+                {
+                    SourceType = source,
+                    TargetType = targetFullName,
+                    Kind = RelationshipKind.References,
+                    Label = $"invokes {methodName}()"
+                });
+            }
+        }
+
+        CrossReferenceCommandHandlerTargets(commandHandlerTargetNodes, commandHandlerNodes);
 
         // Repository → aggregate
         foreach (var repo in repositoryNodes.Where(r => r.ManagesAggregate is not null))
@@ -1145,22 +1183,80 @@ internal sealed class AssemblyScanner
                 results.Add((targetFullName, methodName));
         }
 
-        ScanTypeMethodsForAggregateCalls(handlerType, aggregateFullNames, OnCall);
+        ScanTypeForInstanceCallsOnTypes(handlerType, aggregateFullNames, OnCall);
 
         foreach (var nested in handlerType.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
         {
             if (nested.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 0)
                 continue;
 
-            ScanTypeMethodsForAggregateCalls(nested, aggregateFullNames, OnCall);
+            ScanTypeForInstanceCallsOnTypes(nested, aggregateFullNames, OnCall);
         }
 
         return results;
     }
 
-    private static void ScanTypeMethodsForAggregateCalls(
+    /// <summary>
+    /// Finds instance method calls whose declaring type is a known command handler type
+    /// (e.g. mediator dispatch to another handler), including inside async state machines.
+    /// </summary>
+    private static List<(string TargetFullName, string MethodName)> DetectInvocationsOnDeclaredTypes(
+        Type handlerType,
+        HashSet<string> declaringTypeFullNames)
+    {
+        var results = new List<(string, string)>();
+        var seen = new HashSet<(string Target, string Method)>();
+
+        void OnCall(string targetFullName, string methodName)
+        {
+            if (seen.Add((targetFullName, methodName)))
+                results.Add((targetFullName, methodName));
+        }
+
+        ScanTypeForInstanceCallsOnTypes(handlerType, declaringTypeFullNames, OnCall);
+
+        foreach (var nested in handlerType.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
+        {
+            if (nested.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 0)
+                continue;
+
+            ScanTypeForInstanceCallsOnTypes(nested, declaringTypeFullNames, OnCall);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Finds <c>newobj</c> instructions that construct types in <paramref name="typeFullNames"/>
+    /// (e.g. command DTOs created in an event handler).
+    /// </summary>
+    private static List<string> DetectInstantiatedTypes(Type handlerType, HashSet<string> typeFullNames)
+    {
+        var results = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        void OnCtor(string typeFullName)
+        {
+            if (seen.Add(typeFullName))
+                results.Add(typeFullName);
+        }
+
+        ScanTypeForNewObjOfTypes(handlerType, typeFullNames, OnCtor);
+
+        foreach (var nested in handlerType.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
+        {
+            if (nested.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 0)
+                continue;
+
+            ScanTypeForNewObjOfTypes(nested, typeFullNames, OnCtor);
+        }
+
+        return results;
+    }
+
+    private static void ScanTypeForInstanceCallsOnTypes(
         Type type,
-        HashSet<string> aggregateFullNames,
+        HashSet<string> declaringTypeFullNames,
         Action<string, string> onCall)
     {
         var allMethods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
@@ -1168,13 +1264,13 @@ internal sealed class AssemblyScanner
             .Concat(type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static));
 
         foreach (var method in allMethods)
-            ScanMethodBodyForCallsOnAggregates(method, type.Module, aggregateFullNames, onCall);
+            ScanMethodBodyForInstanceCallsOnTypes(method, type.Module, declaringTypeFullNames, onCall);
     }
 
-    private static void ScanMethodBodyForCallsOnAggregates(
+    private static void ScanMethodBodyForInstanceCallsOnTypes(
         MethodBase method,
         Module module,
-        HashSet<string> aggregateFullNames,
+        HashSet<string> declaringTypeFullNames,
         Action<string, string> onCall)
     {
         System.Reflection.MethodBody? body;
@@ -1219,10 +1315,74 @@ internal sealed class AssemblyScanner
                 var decl = mi.DeclaringType;
                 if (decl?.FullName is not { } declFullName)
                     continue;
-                if (!aggregateFullNames.Contains(declFullName))
+                if (!declaringTypeFullNames.Contains(declFullName))
                     continue;
 
                 onCall(declFullName, mi.Name);
+            }
+            catch
+            {
+                // Token might not be a method token
+            }
+
+            i += 4;
+        }
+    }
+
+    private static void ScanTypeForNewObjOfTypes(Type type, HashSet<string> typeFullNames, Action<string> onCtor)
+    {
+        var allMethods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Cast<MethodBase>()
+            .Concat(type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static));
+
+        foreach (var method in allMethods)
+            ScanMethodBodyForNewObjOfTypes(method, type.Module, typeFullNames, onCtor);
+    }
+
+    private static void ScanMethodBodyForNewObjOfTypes(
+        MethodBase method,
+        Module module,
+        HashSet<string> typeFullNames,
+        Action<string> onCtor)
+    {
+        System.Reflection.MethodBody? body;
+        try { body = method.GetMethodBody(); }
+        catch { return; }
+
+        if (body is null)
+            return;
+
+        var il = body.GetILAsByteArray();
+        if (il is null)
+            return;
+
+        const byte newobj = 0x73;
+
+        for (var i = 0; i < il.Length; i++)
+        {
+            if (il[i] != newobj)
+                continue;
+
+            if (i + 4 >= il.Length)
+                continue;
+
+            var token = il[i + 1]
+                      | (il[i + 2] << 8)
+                      | (il[i + 3] << 16)
+                      | (il[i + 4] << 24);
+
+            try
+            {
+                var resolved = module.ResolveMethod(token);
+                if (resolved is not ConstructorInfo ctor)
+                    continue;
+                var decl = ctor.DeclaringType;
+                if (decl?.FullName is not { } declFullName)
+                    continue;
+                if (!typeFullNames.Contains(declFullName))
+                    continue;
+
+                onCtor(declFullName);
             }
             catch
             {

--- a/DomainModeling/Graph/DomainGraph.cs
+++ b/DomainModeling/Graph/DomainGraph.cs
@@ -200,7 +200,10 @@ public sealed class CommandHandlerTargetNode
 
     public List<PropertyInfo> Properties { get; init; } = [];
 
-    /// <summary>Command handlers that reference this type in <see cref="HandlerNode.Handles"/>.</summary>
+    /// <summary>
+    /// Command handlers that reference this type in <see cref="HandlerNode.Handles"/>, and event handlers
+    /// that construct this command type (detected via IL; GitHub #49).
+    /// </summary>
     public List<string> HandledBy { get; init; } = [];
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #49](https://github.com/rubenvanderpol/NetDomainModeling/issues/49): the graph did not show connections when a domain event handler constructs command DTOs or invokes another command handler.

## Changes

- **Command creation (IL `newobj`)**: For each event handler type, scan method bodies (including compiler-generated async state machines) for constructors of types that are already modeled as command-handler targets. Emit a **Handles** relationship with label `creates command`, and append the event handler to `CommandHandlerTargetNode.HandledBy` for that command type.
- **Calls to command handlers**: Scan for instance method calls whose declaring type is a discovered command handler; emit **References** edges with `invokes {method}()` (same pattern as command handler → aggregate).
- **Ordering**: `CrossReferenceCommandHandlerTargets` now runs after these edges are applied so command-handler `Handles` lists stay in sync with merged discoveries.

## Example app

- Added `ProductPriceChangedHandler` in `DomainModeling.Example` (Catalog context): handles `ProductPriceChangedEvent`, creates `RegisterCustomerCommand`, and calls `RegisterCustomerCommandHandler` — visible at `/domain-model` in the example web app.

## Tests

- Extended sample `OrderPlacedHandler` in tests to construct `PlaceOrderCommand` and call `PlaceOrderCommandHandler.HandleAsync`.
- Added `Build_EventHandler_LinksToCommandTarget_AndReferencedCommandHandler` and `Build_ProductPriceChangedHandler_LinksToRegisterCustomerCommand_AndHandler` (example graph).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dff21601-ebbf-4bc2-aefe-448b8f73c9ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dff21601-ebbf-4bc2-aefe-448b8f73c9ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

