### PR TITLE
Link command handlers to repositories (GitHub #51)

### DIFF
--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -470,6 +470,22 @@ public class DDDBuilderTests
             r.TargetType.Contains("Order"));
     }
 
+    /// <summary>
+    /// GitHub #51: command handlers that depend on <c>IRepository&lt;TAggregate&gt;</c> should link to the matching repository node.
+    /// </summary>
+    [Fact]
+    public void Build_CommandHandler_LinksToRepository_WhenConstructorUsesIRepository()
+    {
+        var graph = BuildSampleGraph();
+        var ctx = graph.BoundedContexts.Single();
+
+        ctx.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.References &&
+            r.Label == "uses repository" &&
+            r.SourceType.Contains("PlaceOrderCommandHandler", StringComparison.Ordinal) &&
+            r.TargetType.Contains("OrderRepository", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void ToJson_ProducesValidJson()
     {

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -101,6 +101,41 @@ public class ExampleAppGraphTests
     }
 
     [Fact]
+    public void Build_PlaceOrderCommandHandler_HasReferencesEdge_ToOrderRepository_ForIRepositoryDependency()
+    {
+        var catalogDomainAssembly = typeof(Product).Assembly;
+        var sharedAssembly = GetSharedExampleAssembly(catalogDomainAssembly);
+
+        var graph = DDDBuilder.Create(ctx => ctx
+                .Entities(e => e.InheritsFrom<Entity>())
+                .Aggregates(a => a.InheritsFrom<AggregateRoot>())
+                .ValueObjects(v => v.InheritsFrom<ValueObject>())
+                .DomainEvents(e => e.InheritsFrom<DomainEvent>())
+                .IntegrationEvents(e => e.InheritsFrom<IntegrationEvent>())
+                .EventHandlers(h => h
+                    .Implements(typeof(IEventHandler<>))
+                    .Implements(typeof(IIntegrationEventHandler<>)))
+                .CommandHandlers(h => h.Implements(typeof(ICommandHandler<>)))
+                .Commands(c => c.NameEndsWith("Command"))
+                .Repositories(r => r.Implements(typeof(IRepository<>)))
+            )
+            .WithSharedAssembly(sharedAssembly)
+            .WithSharedAssembly(GetIntegrationEventsAssembly(), "IntegrationContracts")
+            .WithBoundedContext("Catalog", ctx => ctx
+                .WithDomainAssembly(catalogDomainAssembly))
+            .WithBoundedContext("Shipping", ctx => ctx
+                .WithDomainAssembly(typeof(Shipment).Assembly))
+            .Build();
+
+        var catalog = graph.BoundedContexts.Single(c => c.Name == "Catalog");
+        catalog.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.References &&
+            r.Label == "uses repository" &&
+            r.SourceType.Contains("PlaceOrderCommandHandler", StringComparison.Ordinal) &&
+            r.TargetType.Contains("OrderRepository", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Build_ProductPriceChangedHandler_LinksToRegisterCustomerCommand_AndHandler()
     {
         var graph = BuildExampleGraph();

--- a/DomainModeling.Tests/SampleDomain/SampleTypes.cs
+++ b/DomainModeling.Tests/SampleDomain/SampleTypes.cs
@@ -194,7 +194,7 @@ public sealed class Invoice : BaseAggregateRoot
 
 public class OrderPlacedHandler : IEventHandler<OrderPlacedEvent>
 {
-    private readonly PlaceOrderCommandHandler _followUpCommandHandler = new();
+    private readonly PlaceOrderCommandHandler _followUpCommandHandler = new(null!);
 
     public Task HandleAsync(OrderPlacedEvent @event, CancellationToken ct = default)
     {
@@ -238,10 +238,13 @@ public record PlaceOrderCommand(Guid CustomerId, List<string> Products);
 /// <summary>Command DTO with no handler — used to test explicit <c>Commands(...)</c> registration on <c>DDDBuilder</c>.</summary>
 public record UnassignedCommand(string Reason);
 
-public class PlaceOrderCommandHandler : ICommandHandler<PlaceOrderCommand>
+public class PlaceOrderCommandHandler(IRepository<Order> orders) : ICommandHandler<PlaceOrderCommand>
 {
     public Task HandleAsync(PlaceOrderCommand command, CancellationToken ct = default)
-        => Task.CompletedTask;
+    {
+        ArgumentNullException.ThrowIfNull(orders);
+        return Task.CompletedTask;
+    }
 }
 
 public record GetOrderQuery(Guid OrderId);

--- a/DomainModeling/Builder/TypeConventionBuilder.cs
+++ b/DomainModeling/Builder/TypeConventionBuilder.cs
@@ -179,6 +179,10 @@ public sealed class TypeConventionBuilder
         if (!target.IsGenericTypeDefinition)
             return false;
 
+        // Closed generic interface (e.g. IRepository<Order>) satisfies Implements(typeof(IRepository<>))
+        if (candidate.IsGenericType && candidate.GetGenericTypeDefinition() == target)
+            return true;
+
         // Check open-generic base classes
         var current = candidate.BaseType;
         while (current is not null)

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -264,6 +264,27 @@ internal sealed class AssemblyScanner
 
         CrossReferenceCommandHandlerTargets(commandHandlerTargetNodes, commandHandlerNodes);
 
+        // CommandHandler → repository (constructor / field / property dependency on IRepository<T> or concrete repo; GitHub #51)
+        var aggregateFullNamesForRepos = new HashSet<string>(
+            aggregateNodes.Select(a => a.FullName),
+            StringComparer.Ordinal);
+        foreach (var handlerType in commandHandlerTypes)
+        {
+            foreach (var repoFullName in DetectCommandHandlerRepositoryDependencies(
+                         handlerType,
+                         repositoryNodes,
+                         aggregateFullNamesForRepos))
+            {
+                relationships.Add(new Relationship
+                {
+                    SourceType = handlerType.FullName!,
+                    TargetType = repoFullName,
+                    Kind = RelationshipKind.References,
+                    Label = "uses repository"
+                });
+            }
+        }
+
         // Repository → aggregate
         foreach (var repo in repositoryNodes.Where(r => r.ManagesAggregate is not null))
         {
@@ -629,6 +650,83 @@ internal sealed class AssemblyScanner
                     node.HandledBy.Add(handler.FullName);
             }
         }
+    }
+
+    /// <summary>
+    /// Finds repository dependencies for a command handler: primary constructor parameters, instance fields,
+    /// and instance properties on the declared type. Matches concrete repository classes and closed
+    /// <c>IRepository&lt;TAggregate&gt;</c>-style interfaces that satisfy <see cref="BoundedContextBuilder.RepositoryConvention"/>.
+    /// </summary>
+    private List<string> DetectCommandHandlerRepositoryDependencies(
+        Type handlerType,
+        List<RepositoryNode> repositoryNodes,
+        HashSet<string> aggregateFullNames)
+    {
+        if (repositoryNodes.Count == 0)
+            return [];
+
+        var results = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var repoByFullName = repositoryNodes.ToDictionary(r => r.FullName, StringComparer.Ordinal);
+
+        var reposByAggregate = repositoryNodes
+            .Where(r => r.ManagesAggregate is not null)
+            .GroupBy(r => r.ManagesAggregate!, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+        void TryAdd(string? repoFullName)
+        {
+            if (repoFullName is null || !repoByFullName.ContainsKey(repoFullName))
+                return;
+            if (seen.Add(repoFullName))
+                results.Add(repoFullName);
+        }
+
+        void ConsiderType(Type? t)
+        {
+            if (t is null)
+                return;
+
+            if (t.FullName is not null && repoByFullName.ContainsKey(t.FullName))
+            {
+                TryAdd(t.FullName);
+                return;
+            }
+
+            // Use the closed generic (e.g. IRepository<Order>): Implements() excludes the open-generic
+            // definition itself (t != interfaceType), so Matches(IRepository<>.GetGenericTypeDefinition()) is always false.
+            if (t is { IsGenericType: true }
+                && t.GetGenericArguments().Length == 1
+                && _config.RepositoryConvention.Matches(t))
+            {
+                var aggFn = t.GetGenericArguments()[0].FullName;
+                if (aggFn is not null
+                    && aggregateFullNames.Contains(aggFn)
+                    && reposByAggregate.TryGetValue(aggFn, out var repos))
+                {
+                    foreach (var r in repos)
+                        TryAdd(r.FullName);
+                }
+            }
+        }
+
+        foreach (var ctor in handlerType.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            foreach (var p in ctor.GetParameters())
+                ConsiderType(p.ParameterType);
+        }
+
+        foreach (var field in handlerType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            ConsiderType(field.FieldType);
+
+        foreach (var prop in handlerType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            if (prop.GetIndexParameters().Length > 0)
+                continue;
+            ConsiderType(prop.PropertyType);
+        }
+
+        return results;
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **command handler → repository** edges to the domain graph when a handler depends on a repository abstraction or concrete repository type (primary constructor parameters, instance fields, and instance properties on the declared type).

Edges use `RelationshipKind.References` with label **`uses repository`**, so the existing diagram pipeline (which only draws edges when both endpoints are nodes) shows the link.

## Implementation notes

- For `IRepository<TAggregate>` (and any type matching the configured repository convention with one generic argument), the scanner resolves the managed aggregate and links to **each** discovered repository class that `ManagesAggregate` for that aggregate (typical case: one implementation).
- **Bug fix:** `TypeConventionBuilder.IsAssignableToGenericOrConcrete` did not treat a **closed** generic interface (e.g. `IRepository<Order>`) as implementing `Implements(typeof(IRepository<>))`, which blocked matching repository-like parameter types. Added an explicit check: `candidate.GetGenericTypeDefinition() == target` when `target` is a generic type definition.

## Tests

- Sample domain: `PlaceOrderCommandHandler` now takes `IRepository<Order>`; asserts a References edge to `OrderRepository`.
- Example app graph: asserts `PlaceOrderCommandHandler` → `OrderRepository` in the Catalog context.

Closes #51.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2910b31-f61e-4db7-8241-7d00748ad451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2910b31-f61e-4db7-8241-7d00748ad451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

