### PR TITLE
Add AddDomainEvent and generic EntityDeletedEvent example

### DIFF
--- a/DomainModeling.Example.Shared/Domain.cs
+++ b/DomainModeling.Example.Shared/Domain.cs
@@ -11,7 +11,13 @@ public abstract class AggregateRoot : Entity
 {
     private readonly List<DomainEvent> _events = [];
     public IReadOnlyCollection<DomainEvent> Events => _events.AsReadOnly();
-    protected void Raise(DomainEvent @event) => _events.Add(@event);
+
+    /// <summary>
+    /// Records a domain event raised by this aggregate (alias for the common <c>Raise</c> pattern).
+    /// </summary>
+    protected void AddDomainEvent(DomainEvent @event) => _events.Add(@event);
+
+    protected void Raise(DomainEvent @event) => AddDomainEvent(@event);
 }
 
 public abstract class DomainEvent

--- a/DomainModeling.Example.Shared/Domain.cs
+++ b/DomainModeling.Example.Shared/Domain.cs
@@ -1,5 +1,15 @@
 namespace DomainModeling.Example.Domain;
 
+// ─── Marker (optional second axis for domain event discovery) ───
+
+/// <summary>
+/// Marker for all domain events. Class events typically inherit <see cref="DomainEvent"/>; record events implement this directly (records cannot inherit non-record base classes).
+/// </summary>
+public interface IDomainEvent
+{
+    DateTime OccurredOn { get; }
+}
+
 // ─── Base classes ────────────────────────────────────────────────
 
 public abstract class Entity
@@ -9,18 +19,25 @@ public abstract class Entity
 
 public abstract class AggregateRoot : Entity
 {
-    private readonly List<DomainEvent> _events = [];
-    public IReadOnlyCollection<DomainEvent> Events => _events.AsReadOnly();
+    private readonly List<IDomainEvent> _events = [];
+    public IReadOnlyCollection<IDomainEvent> Events => _events.AsReadOnly();
 
     /// <summary>
     /// Records a domain event raised by this aggregate (alias for the common <c>Raise</c> pattern).
     /// </summary>
-    protected void AddDomainEvent(DomainEvent @event) => _events.Add(@event);
+    protected void AddDomainEvent(IDomainEvent @event) => _events.Add(@event);
 
     protected void Raise(DomainEvent @event) => AddDomainEvent(@event);
+
+    /// <summary>
+    /// Optional hook for deletion flows; overrides may raise <see cref="EntityDeletedEvent{TEntity}"/>.
+    /// </summary>
+    public virtual void DeleteEntity()
+    {
+    }
 }
 
-public abstract class DomainEvent
+public abstract class DomainEvent : IDomainEvent
 {
     public DateTime OccurredOn { get; init; } = DateTime.UtcNow;
 }
@@ -29,7 +46,7 @@ public abstract class ValueObject;
 
 // ─── Handler contracts ───────────────────────────────────────────
 
-public interface IEventHandler<in TEvent> where TEvent : DomainEvent
+public interface IEventHandler<in TEvent> where TEvent : IDomainEvent
 {
     Task HandleAsync(TEvent @event, CancellationToken ct = default);
 }

--- a/DomainModeling.Example.Shared/SharedOnlyCatalogEvent.cs
+++ b/DomainModeling.Example.Shared/SharedOnlyCatalogEvent.cs
@@ -1,0 +1,7 @@
+namespace DomainModeling.Example.Domain;
+
+/// <summary>
+/// Domain event type defined only in the shared kernel assembly (regression: must still be detected when emitted
+/// from a bounded context that references shared types via <c>WithSharedAssembly</c>).
+/// </summary>
+public sealed class SharedOnlyCatalogEvent : DomainEvent;

--- a/DomainModeling.Example/Domain/Aggregates.cs
+++ b/DomainModeling.Example/Domain/Aggregates.cs
@@ -74,3 +74,19 @@ public class Customer : AggregateRoot
         Raise(new CustomerRegisteredEvent { CustomerId = Id });
     }
 }
+
+/// <summary>
+/// Example aggregate that raises a closed generic domain event via <see cref="AggregateRoot.AddDomainEvent"/>.
+/// </summary>
+public class Organization : AggregateRoot
+{
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Illustrates tracking a generic domain event from the aggregate instance.
+    /// </summary>
+    public void Archive()
+    {
+        AddDomainEvent(new EntityDeletedEvent<Organization>(this));
+    }
+}

--- a/DomainModeling.Example/Domain/Aggregates.cs
+++ b/DomainModeling.Example/Domain/Aggregates.cs
@@ -35,6 +35,7 @@ public class Product : AggregateRoot
             OldPrice = Price,
             NewPrice = newPrice
         });
+        AddDomainEvent(new SharedOnlyCatalogEvent());
         Price = newPrice;
     }
 }

--- a/DomainModeling.Example/Domain/Aggregates.cs
+++ b/DomainModeling.Example/Domain/Aggregates.cs
@@ -83,9 +83,9 @@ public class Organization : AggregateRoot
     public required string Name { get; init; }
 
     /// <summary>
-    /// Illustrates tracking a generic domain event from the aggregate instance.
+    /// Illustrates tracking a generic record domain event from an overridden method.
     /// </summary>
-    public void Archive()
+    public override void DeleteEntity()
     {
         AddDomainEvent(new EntityDeletedEvent<Organization>(this));
     }

--- a/DomainModeling.Example/Domain/Events.cs
+++ b/DomainModeling.Example/Domain/Events.cs
@@ -44,22 +44,10 @@ public sealed class CustomerRegisteredEvent : DomainEvent
 }
 
 /// <summary>
-/// A generic domain event raised when any entity is deleted.
+/// A generic domain event raised when any entity is deleted (record primary constructor).
 /// </summary>
-public sealed class EntityDeletedEvent<TEntity> : DomainEvent where TEntity : Entity
+public record EntityDeletedEvent<TEntity>(TEntity Entity) : IDomainEvent where TEntity : Entity
 {
-    public Guid EntityId { get; init; }
-
-    public EntityDeletedEvent()
-    {
-    }
-
-    /// <summary>
-    /// Captures the deleted entity's id, e.g. <c>AddDomainEvent(new EntityDeletedEvent&lt;Organization&gt;(this))</c>.
-    /// </summary>
-    public EntityDeletedEvent(TEntity entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-        EntityId = entity.Id;
-    }
+    public DateTime OccurredOn { get; init; } = DateTime.UtcNow;
+    public Guid EntityId { get; init; } = Entity.Id;
 }

--- a/DomainModeling.Example/Domain/Events.cs
+++ b/DomainModeling.Example/Domain/Events.cs
@@ -49,4 +49,17 @@ public sealed class CustomerRegisteredEvent : DomainEvent
 public sealed class EntityDeletedEvent<TEntity> : DomainEvent where TEntity : Entity
 {
     public Guid EntityId { get; init; }
+
+    public EntityDeletedEvent()
+    {
+    }
+
+    /// <summary>
+    /// Captures the deleted entity's id, e.g. <c>AddDomainEvent(new EntityDeletedEvent&lt;Organization&gt;(this))</c>.
+    /// </summary>
+    public EntityDeletedEvent(TEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        EntityId = entity.Id;
+    }
 }

--- a/DomainModeling.Example/Domain/Handlers.cs
+++ b/DomainModeling.Example/Domain/Handlers.cs
@@ -52,6 +52,12 @@ public class CustomerDeletedHandler : IEventHandler<EntityDeletedEvent<Customer>
         => Task.CompletedTask;
 }
 
+public class OrganizationDeletedHandler : IEventHandler<EntityDeletedEvent<Organization>>
+{
+    public Task HandleAsync(EntityDeletedEvent<Organization> @event, CancellationToken ct = default)
+        => Task.CompletedTask;
+}
+
 // ─── Command handlers ────────────────────────────────────────────
 
 public record PlaceOrderCommand(Guid CustomerId, List<string> Products);
@@ -84,4 +90,5 @@ public class RegisterCustomerCommandHandler : ICommandHandler<RegisterCustomerCo
 
 public class OrderRepository : InMemoryRepository<Order>;
 public class CustomerRepository : InMemoryRepository<Customer>;
+public class OrganizationRepository : InMemoryRepository<Organization>;
 public class ProductRepository : InMemoryRepository<Product>;

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddMediatR(cfg =>
 // Register in-memory repositories
 builder.Services.AddSingleton<IRepository<Order>, OrderRepository>();
 builder.Services.AddSingleton<IRepository<Customer>, CustomerRepository>();
+builder.Services.AddSingleton<IRepository<Organization>, OrganizationRepository>();
 builder.Services.AddSingleton<IRepository<Product>, ProductRepository>();
 builder.Services.AddSingleton<IRepository<Shipment>, ShipmentRepository>();
 builder.Services.AddSingleton<IRepository<Carrier>, CarrierRepository>();

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -19,7 +19,7 @@ var domainGraph = DDDBuilder.Create(ctx => ctx
         .Entities(e => e.InheritsFrom<Entity>())
         .Aggregates(a => a.InheritsFrom<AggregateRoot>())
         .ValueObjects(v => v.InheritsFrom<ValueObject>())
-        .DomainEvents(e => e.InheritsFrom<DomainEvent>())
+        .DomainEvents(e => e.InheritsFrom<DomainEvent>().Or().Implements(typeof(IDomainEvent)))
         .IntegrationEvents(e => e.InheritsFrom<IntegrationEvent>())
         .EventHandlers(h => h
             .Implements(typeof(IEventHandler<>))

--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -72,7 +72,7 @@ public class DDDBuilderTests
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        ctx.DomainEvents.Should().HaveCount(7);
+        ctx.DomainEvents.Should().HaveCount(6);
         ctx.DomainEvents.Select(e => e.Name).Should()
             .Contain(["OrderPlacedEvent", "OrderShippedEvent", "CustomerCreatedEvent", "InvoiceCreatedEvent"]);
         ctx.DomainEvents.Should().Contain(e => e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal));
@@ -327,33 +327,31 @@ public class DDDBuilderTests
     }
 
     [Fact]
-    public void Build_GenericDomainEvent_HandlerLinksToOpenGenericEventNode()
+    public void Build_GenericDomainEvent_HandlerLinksToClosedGenericEventNode()
     {
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        var genericEvent = ctx.DomainEvents.Single(e =>
-            e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal) && !e.Name.Contains('<'));
-        genericEvent.HandledBy.Should().Contain(h => h.Contains("OrderDeletedEventHandler"));
+        var orderDeleted = ctx.DomainEvents.Single(e => e.Name == "EntityDeletedEvent<Order>");
+        orderDeleted.HandledBy.Should().Contain(h => h.Contains("OrderDeletedEventHandler"));
 
         ctx.Relationships.Should().Contain(r =>
             r.Kind == RelationshipKind.Handles &&
             r.SourceType.Contains("OrderDeletedEventHandler", StringComparison.Ordinal) &&
-            r.TargetType == genericEvent.FullName);
+            r.TargetType == orderDeleted.FullName);
     }
 
     [Fact]
-    public void Build_GenericDomainEvent_EmissionUsesOpenGenericEventKey()
+    public void Build_GenericDomainEvent_EmissionUsesClosedGenericEventKey()
     {
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        var genericEvent = ctx.DomainEvents.Single(e =>
-            e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal) && !e.Name.Contains('<'));
-        genericEvent.EmittedBy.Should().Contain(e => e.Contains("Order"));
+        var orderDeleted = ctx.DomainEvents.Single(e => e.Name == "EntityDeletedEvent<Order>");
+        orderDeleted.EmittedBy.Should().Contain(e => e.Contains("Order"));
 
         var order = ctx.Aggregates.Single(a => a.Name == "Order");
-        order.EmittedEvents.Should().Contain(genericEvent.FullName);
+        order.EmittedEvents.Should().Contain(orderDeleted.FullName);
     }
 
     [Fact]
@@ -430,16 +428,24 @@ public class DDDBuilderTests
     }
 
     [Fact]
-    public void Build_TypeDocumentedEmits_OpenGenericNodeStillExistsAndHandlerStillLinked()
+    public void Build_OpenGenericEntityDeletedEventDefinition_IsNotListedAsDomainEvent()
     {
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        var openGenericEvent = ctx.DomainEvents.Single(e =>
-            e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal) &&
-            !e.Name.Contains("<"));
-        openGenericEvent.HandledBy.Should().Contain(h => h.Contains("OrderDeletedEventHandler"));
-        openGenericEvent.EmittedBy.Should().Contain(e => e.Contains("Order"));
+        ctx.DomainEvents.Should().NotContain(e =>
+            e.FullName == "DomainModeling.Tests.SampleDomain.EntityDeletedEvent`1");
+    }
+
+    [Fact]
+    public void Build_TypeDocumentedEmits_OrderHandlerStillLinkedToClosedGenericOrderDeleted()
+    {
+        var graph = BuildSampleGraph();
+        var ctx = graph.BoundedContexts.Single();
+
+        var orderDeleted = ctx.DomainEvents.Single(e => e.Name == "EntityDeletedEvent<Order>");
+        orderDeleted.HandledBy.Should().Contain(h => h.Contains("OrderDeletedEventHandler"));
+        orderDeleted.EmittedBy.Should().Contain(e => e.Contains("Order"));
     }
 
     [Fact]

--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -72,11 +72,12 @@ public class DDDBuilderTests
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        ctx.DomainEvents.Should().HaveCount(6);
+        ctx.DomainEvents.Should().HaveCount(7);
         ctx.DomainEvents.Select(e => e.Name).Should()
             .Contain(["OrderPlacedEvent", "OrderShippedEvent", "CustomerCreatedEvent", "InvoiceCreatedEvent"]);
         ctx.DomainEvents.Should().Contain(e => e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal));
         ctx.DomainEvents.Should().Contain(e => e.Name == "EntityDeletedEvent<Customer>");
+        ctx.DomainEvents.Should().Contain(e => e.Name == "EntityDeletedEvent<Order>");
     }
 
     [Fact]

--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -23,7 +23,7 @@ public class DDDBuilderTests
                 .Entities(e => e.InheritsFrom<BaseEntity>())
                 .Aggregates(a => a.InheritsFrom<BaseAggregateRoot>())
                 .ValueObjects(v => v.InheritsFrom<BaseValueObject>())
-                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<BaseIntegrationEvent>())
                 .EventHandlers(h => h
                     .Implements(typeof(IEventHandler<>))
@@ -72,7 +72,7 @@ public class DDDBuilderTests
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        ctx.DomainEvents.Should().HaveCount(6);
+        ctx.DomainEvents.Should().HaveCount(7);
         ctx.DomainEvents.Select(e => e.Name).Should()
             .Contain(["OrderPlacedEvent", "OrderShippedEvent", "CustomerCreatedEvent", "InvoiceCreatedEvent"]);
         ctx.DomainEvents.Should().Contain(e => e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal));
@@ -86,7 +86,7 @@ public class DDDBuilderTests
         var graph = BuildSampleGraph();
         var ctx = graph.BoundedContexts.Single();
 
-        ctx.EventHandlers.Should().HaveCount(5);
+        ctx.EventHandlers.Should().HaveCount(6);
         ctx.CommandHandlers.Should().ContainSingle(h => h.Name == "PlaceOrderCommandHandler");
         ctx.QueryHandlers.Should().ContainSingle(h => h.Name == "GetOrderQueryHandler");
     }
@@ -438,6 +438,22 @@ public class DDDBuilderTests
     }
 
     [Fact]
+    public void Build_RecordGenericEvent_FromOverrideDeclaredOnBaseType_IsEmittedAndHandled()
+    {
+        var graph = BuildSampleGraph();
+        var ctx = graph.BoundedContexts.Single();
+
+        var closed = ctx.DomainEvents.Single(e => e.Name == "EntityDeletedEvent<RecordDeleteSample>");
+        closed.EmittedBy.Should().Contain(e => e.Contains("RecordDeleteSample", StringComparison.Ordinal));
+        closed.HandledBy.Should().Contain(h => h.Contains("RecordDeleteSampleDeletedEventHandler"));
+
+        ctx.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.Handles &&
+            r.SourceType.Contains("RecordDeleteSampleDeletedEventHandler", StringComparison.Ordinal) &&
+            r.TargetType == closed.FullName);
+    }
+
+    [Fact]
     public void Build_TypeDocumentedEmits_OrderHandlerStillLinkedToClosedGenericOrderDeleted()
     {
         var graph = BuildSampleGraph();
@@ -521,7 +537,7 @@ public class DDDBuilderTests
                 .WithApplicationAssembly(assembly)
                 .Entities(e => e.InheritsFrom<BaseEntity>())
                 .Aggregates(a => a.InheritsFrom<BaseAggregateRoot>())
-                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<BaseIntegrationEvent>())
                 .EventHandlers(h => h.NameEndsWith("EventHandler"))
             )
@@ -554,7 +570,7 @@ public class DDDBuilderTests
                 .WithApplicationAssembly(assembly)
                 .Entities(e => e.InheritsFrom<BaseEntity>())
                 .Aggregates(a => a.InheritsFrom<BaseAggregateRoot>())
-                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<BaseIntegrationEvent>())
                 .EventHandlers(h => h.NameEndsWith("EventHandler"))
             )
@@ -619,11 +635,12 @@ public class DDDBuilderTests
             .Build();
 
         var ctx = graph.BoundedContexts.Single();
-        ctx.EventHandlers.Should().HaveCount(4);
+        ctx.EventHandlers.Should().HaveCount(5);
         ctx.EventHandlers.Should().Contain(h => h.Name == "OrderPlacedHandler");
         ctx.EventHandlers.Should().Contain(h => h.Name == "SendShipmentNotificationHandler");
         ctx.EventHandlers.Should().Contain(h => h.Name == "OrderDeletedEventHandler");
         ctx.EventHandlers.Should().Contain(h => h.Name == "CustomerDeletedEventHandler");
+        ctx.EventHandlers.Should().Contain(h => h.Name == "RecordDeleteSampleDeletedEventHandler");
         ctx.EventHandlers.Should().NotContain(h => h.Name == "OrderPlacedIntegrationHandler");
         ctx.EventHandlers.Should().NotContain(h => h.Name.Contains("PublishCustomerRegistered"));
     }
@@ -644,7 +661,7 @@ public class DDDBuilderTests
             .Build();
 
         var ctx = graph.BoundedContexts.Single();
-        ctx.EventHandlers.Should().HaveCount(5);
+        ctx.EventHandlers.Should().HaveCount(6);
     }
 
     [Fact]
@@ -825,7 +842,7 @@ public class DDDBuilderTests
             .WithBoundedContext("ContextA", ctx => ctx
                 .WithDomainAssembly(assembly)
                 .Aggregates(a => a.InheritsFrom<BaseAggregateRoot>())
-                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<BaseDomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<BaseIntegrationEvent>())
                 .EventHandlers(h => h.Implements(typeof(IEventHandler<>)))
             )

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -186,16 +186,11 @@ public class ExampleAppGraphTests
         var graph = BuildExampleGraph();
         var catalog = graph.BoundedContexts.Single(c => c.Name == "Catalog");
 
-        // IL records closed-generic construction, but the graph merges emissions onto the open generic
-        // event node when no separate closed-generic node exists (see DDDBuilderTests generic event tests).
-        var entityDeletedOpen = catalog.DomainEvents.Single(e =>
-            e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal) &&
-            !e.Name.Contains('<', StringComparison.Ordinal));
-
-        entityDeletedOpen.EmittedBy.Should().Contain(e => e.Contains("Organization", StringComparison.Ordinal));
-        entityDeletedOpen.HandledBy.Should().Contain(h => h.Contains("OrganizationDeletedHandler", StringComparison.Ordinal));
+        var deletedOrg = catalog.DomainEvents.Single(e => e.Name == "EntityDeletedEvent<Organization>");
+        deletedOrg.EmittedBy.Should().Contain(e => e.Contains("Organization", StringComparison.Ordinal));
+        deletedOrg.HandledBy.Should().Contain(h => h.Contains("OrganizationDeletedHandler", StringComparison.Ordinal));
 
         var org = catalog.Aggregates.Single(a => a.Name == "Organization");
-        org.EmittedEvents.Should().Contain(entityDeletedOpen.FullName);
+        org.EmittedEvents.Should().Contain(deletedOrg.FullName);
     }
 }

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -179,4 +179,23 @@ public class ExampleAppGraphTests
         evt.EmittedBy.Should().Contain(h => h.Contains("OrderPlacedHandler", StringComparison.Ordinal));
         evt.HandledBy.Should().Contain(h => h.Contains("OrderPlacedIntegrationHandler", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void Build_AddDomainEvent_GenericClosedEvent_IsEmittedByAggregateAndHandled()
+    {
+        var graph = BuildExampleGraph();
+        var catalog = graph.BoundedContexts.Single(c => c.Name == "Catalog");
+
+        // IL records closed-generic construction, but the graph merges emissions onto the open generic
+        // event node when no separate closed-generic node exists (see DDDBuilderTests generic event tests).
+        var entityDeletedOpen = catalog.DomainEvents.Single(e =>
+            e.Name.StartsWith("EntityDeletedEvent", StringComparison.Ordinal) &&
+            !e.Name.Contains('<', StringComparison.Ordinal));
+
+        entityDeletedOpen.EmittedBy.Should().Contain(e => e.Contains("Organization", StringComparison.Ordinal));
+        entityDeletedOpen.HandledBy.Should().Contain(h => h.Contains("OrganizationDeletedHandler", StringComparison.Ordinal));
+
+        var org = catalog.Aggregates.Single(a => a.Name == "Organization");
+        org.EmittedEvents.Should().Contain(entityDeletedOpen.FullName);
+    }
 }

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -204,4 +204,14 @@ public class ExampleAppGraphTests
         var orgHandler = catalog.EventHandlers.Single(h => h.Name == "OrganizationDeletedHandler");
         orgHandler.Handles.Should().Contain(deletedOrg.FullName);
     }
+
+    [Fact]
+    public void Build_SharedKernelDomainEvent_IsDiscovered_WhenTypeExistsOnlyInSharedAssembly()
+    {
+        var graph = BuildExampleGraph();
+        var catalog = graph.BoundedContexts.Single(c => c.Name == "Catalog");
+
+        var evt = catalog.DomainEvents.Single(e => e.Name == "SharedOnlyCatalogEvent");
+        catalog.Aggregates.Single(a => a.Name == "Product").EmittedEvents.Should().Contain(evt.FullName);
+    }
 }

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -35,7 +35,7 @@ public class ExampleAppGraphTests
                 .Entities(e => e.InheritsFrom<Entity>())
                 .Aggregates(a => a.InheritsFrom<AggregateRoot>())
                 .ValueObjects(v => v.InheritsFrom<ValueObject>())
-                .DomainEvents(e => e.InheritsFrom<DomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<DomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<IntegrationEvent>())
                 .EventHandlers(h => h
                     .Implements(typeof(IEventHandler<>))
@@ -74,7 +74,7 @@ public class ExampleAppGraphTests
                 .Entities(e => e.InheritsFrom<Entity>())
                 .Aggregates(a => a.InheritsFrom<AggregateRoot>())
                 .ValueObjects(v => v.InheritsFrom<ValueObject>())
-                .DomainEvents(e => e.InheritsFrom<DomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<DomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<IntegrationEvent>())
                 .EventHandlers(h => h
                     .Implements(typeof(IEventHandler<>))
@@ -130,7 +130,7 @@ public class ExampleAppGraphTests
                 .Entities(e => e.InheritsFrom<Entity>())
                 .Aggregates(a => a.InheritsFrom<AggregateRoot>())
                 .ValueObjects(v => v.InheritsFrom<ValueObject>())
-                .DomainEvents(e => e.InheritsFrom<DomainEvent>())
+                .DomainEvents(e => e.InheritsFrom<DomainEvent>().Or().Implements(typeof(IDomainEvent)))
                 .IntegrationEvents(e => e.InheritsFrom<IntegrationEvent>())
                 .EventHandlers(h => h
                     .Implements(typeof(IEventHandler<>))
@@ -200,5 +200,8 @@ public class ExampleAppGraphTests
 
         catalog.DomainEvents.Should().NotContain(e =>
             e.FullName == "DomainModeling.Example.Domain.EntityDeletedEvent`1");
+
+        var orgHandler = catalog.EventHandlers.Single(h => h.Name == "OrganizationDeletedHandler");
+        orgHandler.Handles.Should().Contain(deletedOrg.FullName);
     }
 }

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -197,5 +197,8 @@ public class ExampleAppGraphTests
             r.Kind == RelationshipKind.Handles &&
             r.SourceType.Contains("OrganizationDeletedHandler", StringComparison.Ordinal) &&
             r.TargetType == deletedOrg.FullName);
+
+        catalog.DomainEvents.Should().NotContain(e =>
+            e.FullName == "DomainModeling.Example.Domain.EntityDeletedEvent`1");
     }
 }

--- a/DomainModeling.Tests/ExampleAppGraphTests.cs
+++ b/DomainModeling.Tests/ExampleAppGraphTests.cs
@@ -192,5 +192,10 @@ public class ExampleAppGraphTests
 
         var org = catalog.Aggregates.Single(a => a.Name == "Organization");
         org.EmittedEvents.Should().Contain(deletedOrg.FullName);
+
+        catalog.Relationships.Should().Contain(r =>
+            r.Kind == RelationshipKind.Handles &&
+            r.SourceType.Contains("OrganizationDeletedHandler", StringComparison.Ordinal) &&
+            r.TargetType == deletedOrg.FullName);
     }
 }

--- a/DomainModeling.Tests/GenericTypeDisplayNamesTests.cs
+++ b/DomainModeling.Tests/GenericTypeDisplayNamesTests.cs
@@ -1,0 +1,24 @@
+using DomainModeling;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public class GenericTypeDisplayNamesTests
+{
+    [Fact]
+    public void ToCanonicalClosedGenericFullName_StripsAssemblyQualifiers()
+    {
+        var fq =
+            "Ns.EntityDeletedEvent`1[[Ns.Organization, MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]";
+        var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(fq);
+        canonical.Should().Be("Ns.EntityDeletedEvent`1[[Ns.Organization]]");
+    }
+
+    [Fact]
+    public void FormatAsCSharp_UsesAngleBrackets()
+    {
+        var canonical = "DomainModeling.Example.Domain.EntityDeletedEvent`1[[DomainModeling.Example.Domain.Organization]]";
+        GenericTypeDisplayNames.FormatAsCSharp(canonical).Should().Be("EntityDeletedEvent<Organization>");
+    }
+}

--- a/DomainModeling.Tests/GenericTypeDisplayNamesTests.cs
+++ b/DomainModeling.Tests/GenericTypeDisplayNamesTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using DomainModeling;
+using DomainModeling.Tests.SampleDomain;
 using FluentAssertions;
 using Xunit;
 
@@ -12,13 +14,37 @@ public class GenericTypeDisplayNamesTests
         var fq =
             "Ns.EntityDeletedEvent`1[[Ns.Organization, MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]";
         var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(fq);
-        canonical.Should().Be("Ns.EntityDeletedEvent`1[[Ns.Organization]]");
+        canonical.Should().Be("Ns.EntityDeletedEvent[Ns.Organization]");
     }
 
     [Fact]
     public void FormatAsCSharp_UsesAngleBrackets()
     {
-        var canonical = "DomainModeling.Example.Domain.EntityDeletedEvent`1[[DomainModeling.Example.Domain.Organization]]";
+        var canonical =
+            "DomainModeling.Example.Domain.EntityDeletedEvent[DomainModeling.Example.Domain.Organization]";
         GenericTypeDisplayNames.FormatAsCSharp(canonical).Should().Be("EntityDeletedEvent<Organization>");
+    }
+
+    [Fact]
+    public void GetOpenGenericDefinitionWithArity_FromBracketForm()
+    {
+        GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(
+                "DomainModeling.Example.Domain.EntityDeletedEvent[DomainModeling.Example.Domain.Customer]")
+            .Should().Be("DomainModeling.Example.Domain.EntityDeletedEvent`1");
+    }
+
+    [Fact]
+    public void Handler_InterfaceTypeArg_NormalizesToSameKey_AsSyntheticEventNode()
+    {
+        var handler = typeof(OrderDeletedEventHandler);
+        var iface = handler.GetInterfaces().Single(i => i.IsGenericType && i.GetGenericTypeDefinition().Name == "IEventHandler`1");
+        var arg = iface.GetGenericArguments()[0];
+        arg.FullName.Should().NotBeNull();
+        var fromHandler = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(arg.FullName!);
+        fromHandler.Should().NotBeNull();
+        var expected =
+            "DomainModeling.Tests.SampleDomain.EntityDeletedEvent[DomainModeling.Tests.SampleDomain.Order]";
+        fromHandler.Should().Be(expected);
+        GenericTypeDisplayNames.AreSameConstructedGeneric(fromHandler!, expected).Should().BeTrue();
     }
 }

--- a/DomainModeling.Tests/SampleDomain/SampleTypes.cs
+++ b/DomainModeling.Tests/SampleDomain/SampleTypes.cs
@@ -9,6 +9,13 @@
 
 namespace DomainModeling.Tests.SampleDomain;
 
+// ─── Marker for record / interface-based event discovery ─────────
+
+public interface IDomainEvent
+{
+    DateTime OccurredOn { get; }
+}
+
 // ─── Base classes (the project's own DDD building blocks) ────────
 
 public abstract class BaseEntity
@@ -18,12 +25,16 @@ public abstract class BaseEntity
 
 public abstract class BaseAggregateRoot : BaseEntity
 {
-    private readonly List<BaseDomainEvent> _events = [];
-    public IReadOnlyCollection<BaseDomainEvent> Events => _events.AsReadOnly();
-    protected void Raise(BaseDomainEvent @event) => _events.Add(@event);
+    private readonly List<IDomainEvent> _events = [];
+    public IReadOnlyCollection<IDomainEvent> Events => _events.AsReadOnly();
+    protected void Raise(IDomainEvent @event) => _events.Add(@event);
+
+    public virtual void DeleteEntity()
+    {
+    }
 }
 
-public abstract class BaseDomainEvent
+public abstract class BaseDomainEvent : IDomainEvent
 {
     public DateTime OccurredOn { get; init; } = DateTime.UtcNow;
 }
@@ -35,7 +46,7 @@ public abstract class BaseIntegrationEvent
 
 public abstract class BaseValueObject;
 
-public interface IEventHandler<in TEvent> where TEvent : BaseDomainEvent
+public interface IEventHandler<in TEvent> where TEvent : IDomainEvent
 {
     Task HandleAsync(TEvent @event, CancellationToken ct = default);
 }
@@ -94,7 +105,11 @@ public sealed class InvoiceCreatedEvent : BaseDomainEvent
     public Guid InvoiceId { get; init; }
 }
 
-public sealed class EntityDeletedEvent<TEntity> : BaseDomainEvent where TEntity : BaseEntity;
+public record EntityDeletedEvent<TEntity>(TEntity Entity) : IDomainEvent where TEntity : BaseEntity
+{
+    public DateTime OccurredOn { get; init; } = DateTime.UtcNow;
+    public Guid EntityId { get; init; } = Entity.Id;
+}
 
 // ─── Integration Events ───────────────────────────────────────────
 
@@ -156,7 +171,7 @@ public class Order : BaseAggregateRoot
 
     public void Delete()
     {
-        Raise(new EntityDeletedEvent<Order>());
+        Raise(new EntityDeletedEvent<Order>(this));
     }
 }
 
@@ -173,6 +188,19 @@ public class Customer : BaseAggregateRoot
     public void Register()
     {
         Raise(new CustomerCreatedEvent { CustomerId = Id });
+    }
+}
+
+/// <summary>
+/// Used to test record primary-constructor emissions from an overridden method declared on a base type.
+/// </summary>
+public abstract class DeletableAggregateRoot : BaseAggregateRoot;
+
+public class RecordDeleteSample : DeletableAggregateRoot
+{
+    public override void DeleteEntity()
+    {
+        Raise(new EntityDeletedEvent<RecordDeleteSample>(this));
     }
 }
 
@@ -221,6 +249,12 @@ public class OrderDeletedEventHandler : IEventHandler<EntityDeletedEvent<Order>>
 public class CustomerDeletedEventHandler : IEventHandler<EntityDeletedEvent<Customer>>
 {
     public Task HandleAsync(EntityDeletedEvent<Customer> @event, CancellationToken ct = default)
+        => Task.CompletedTask;
+}
+
+public class RecordDeleteSampleDeletedEventHandler : IEventHandler<EntityDeletedEvent<RecordDeleteSample>>
+{
+    public Task HandleAsync(EntityDeletedEvent<RecordDeleteSample> @event, CancellationToken ct = default)
         => Task.CompletedTask;
 }
 

--- a/DomainModeling/Builder/BoundedContextBuilder.cs
+++ b/DomainModeling/Builder/BoundedContextBuilder.cs
@@ -28,6 +28,8 @@ public sealed class BoundedContextBuilder
     /// Assemblies scanned for discovery (handlers, IL, references) in this context, but whose
     /// primary building blocks are listed only under the bounded context name passed to
     /// <c>WithSharedAssembly(assembly, boundedContextName)</c> on <see cref="DDDBuilder"/>.
+    /// Domain event types and event handlers that still match the configured conventions in such an assembly
+    /// are merged into discovery (emission matching, generic handler resolution) and domain event nodes.
     /// </summary>
     internal HashSet<Assembly> ExternallyOwnedSharedAssemblies { get; } = new();
 

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using DomainModeling.Builder;
 using DomainModeling.Graph;
+using DomainModeling;
 using MethodInfo = DomainModeling.Graph.MethodInfo;
 using PropertyInfo = DomainModeling.Graph.PropertyInfo;
 
@@ -100,6 +101,8 @@ internal sealed class AssemblyScanner
             domainEventNodes,
             knownDomainTypes,
             eventHandlerNodes);
+
+        RemapEventHandlerHandlesFromIEventHandlerInterfaces(eventHandlerTypes, domainEventNodes, eventHandlerNodes);
 
         var commandHandlerTargetNodes = DiscoverCommandHandlerTargets(
             allTypes,
@@ -203,7 +206,22 @@ internal sealed class AssemblyScanner
         var registeredEventFullNames = new HashSet<string>(
             domainEventNodes.Select(e => e.FullName).Concat(integrationEventNodes.Select(e => e.FullName)),
             StringComparer.Ordinal);
-        foreach (var handler in eventHandlerNodes.Concat(commandHandlerNodes).Concat(queryHandlerNodes))
+        foreach (var handler in eventHandlerNodes)
+        {
+            foreach (var handled in handler.Handles)
+            {
+                var target = ResolveEmissionEventKey(handled, registeredEventFullNames) ?? handled;
+                relationships.Add(new Relationship
+                {
+                    SourceType = handler.FullName,
+                    TargetType = target,
+                    Kind = RelationshipKind.Handles,
+                    Label = "handles"
+                });
+            }
+        }
+
+        foreach (var handler in commandHandlerNodes.Concat(queryHandlerNodes))
         {
             foreach (var handled in handler.Handles)
             {
@@ -734,7 +752,7 @@ internal sealed class AssemblyScanner
 
         if (type.IsGenericType)
         {
-            var baseName = StripGenericArity(type.Name);
+            var baseName = GenericTypeDisplayNames.StripGenericArity(type.Name);
             var args = string.Join(", ", type.GetGenericArguments().Select(FormatTypeName));
             return $"{baseName}<{args}>";
         }
@@ -769,7 +787,7 @@ internal sealed class AssemblyScanner
 
             // Generic but not a collection (e.g. Nullable<T>)
             var argNames = string.Join(", ", args.Select(a => a.Name));
-            return ($"{StripGenericArity(type.Name)}<{argNames}>", false, null);
+            return ($"{GenericTypeDisplayNames.StripGenericArity(type.Name)}<{argNames}>", false, null);
         }
 
         return (type.Name, false, null);
@@ -785,12 +803,6 @@ internal sealed class AssemblyScanner
             || genericDef == typeof(IReadOnlyList<>)
             || genericDef == typeof(HashSet<>)
             || genericDef == typeof(ISet<>);
-    }
-
-    private static string StripGenericArity(string name)
-    {
-        var idx = name.IndexOf('`');
-        return idx >= 0 ? name[..idx] : name;
     }
 
     /// <summary>
@@ -991,7 +1003,7 @@ internal sealed class AssemblyScanner
         var key = resolvedKey;
         if (key.Contains("[[", StringComparison.Ordinal))
         {
-            var shortForm = ToCanonicalClosedGenericFullName(key);
+            var shortForm = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(key);
             if (shortForm is not null)
                 key = shortForm;
         }
@@ -1110,7 +1122,7 @@ internal sealed class AssemblyScanner
         var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
         if (bracket >= 0)
         {
-            var canonical = ToCanonicalClosedGenericFullName(typeFullName);
+            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
             if (canonical is not null && registeredEventFullNames.Contains(canonical))
                 return canonical;
 
@@ -1135,7 +1147,7 @@ internal sealed class AssemblyScanner
         var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
         if (bracket >= 0)
         {
-            var canonical = ToCanonicalClosedGenericFullName(typeFullName);
+            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
             if (canonical is not null && registeredEventFullNames.Contains(canonical))
                 return canonical;
 
@@ -1145,62 +1157,6 @@ internal sealed class AssemblyScanner
         }
 
         return ResolveCanonicalEventKey(typeFullName, registeredEventFullNames);
-    }
-
-    /// <summary>
-    /// Builds a C#-style display name (e.g. <c>EntityDeletedEvent&lt;Organization&gt;</c>) from a short canonical
-    /// constructed generic <see cref="Type.FullName"/> such as <c>Ns.EntityDeletedEvent`1[[Ns.Organization]]</c>.
-    /// </summary>
-    private static string FormatClosedGenericDisplayName(string canonicalConstructedClrFullName)
-    {
-        var tick = canonicalConstructedClrFullName.IndexOf('`');
-        if (tick < 0)
-            return canonicalConstructedClrFullName;
-
-        var defFqn = canonicalConstructedClrFullName[..tick];
-        var simpleDef = defFqn.Contains('.', StringComparison.Ordinal)
-            ? defFqn[(defFqn.LastIndexOf('.') + 1)..]
-            : defFqn;
-
-        var innerStart = canonicalConstructedClrFullName.IndexOf("[[", StringComparison.Ordinal);
-        if (innerStart < 0)
-            return StripGenericArity(simpleDef);
-
-        var args = new List<string>();
-        var i = innerStart + 1;
-        while (i < canonicalConstructedClrFullName.Length)
-        {
-            if (canonicalConstructedClrFullName[i] != '[')
-            {
-                i++;
-                continue;
-            }
-
-            i++;
-            var argStart = i;
-            var depth = 1;
-            while (i < canonicalConstructedClrFullName.Length && depth > 0)
-            {
-                if (canonicalConstructedClrFullName[i] == '[') depth++;
-                else if (canonicalConstructedClrFullName[i] == ']') depth--;
-                i++;
-            }
-
-            var argSegment = canonicalConstructedClrFullName[argStart..(i - 1)];
-            var comma = argSegment.IndexOf(',', StringComparison.Ordinal);
-            var argType = (comma >= 0 ? argSegment[..comma] : argSegment).Trim();
-            var shortArg = argType.Contains('.', StringComparison.Ordinal)
-                ? argType[(argType.LastIndexOf('.') + 1)..]
-                : argType;
-            args.Add(shortArg);
-
-            if (i < canonicalConstructedClrFullName.Length && canonicalConstructedClrFullName[i] == ',')
-                i++;
-        }
-
-        return args.Count == 0
-            ? StripGenericArity(simpleDef)
-            : $"{StripGenericArity(simpleDef)}<{string.Join(", ", args)}>";
     }
 
     /// <summary>
@@ -1242,7 +1198,7 @@ internal sealed class AssemblyScanner
             if (!key.Contains("[[", StringComparison.Ordinal))
                 continue;
 
-            var canonical = ToCanonicalClosedGenericFullName(key);
+            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(key);
             if (canonical is null || existingEventFullNames.Contains(canonical))
                 continue;
 
@@ -1256,7 +1212,7 @@ internal sealed class AssemblyScanner
 
             domainEventNodes.Add(new DomainEventNode
             {
-                Name = FormatClosedGenericDisplayName(canonical),
+                Name = GenericTypeDisplayNames.FormatAsCSharp(canonical),
                 FullName = canonical,
             });
             existingEventFullNames.Add(canonical);
@@ -1276,59 +1232,62 @@ internal sealed class AssemblyScanner
     }
 
     /// <summary>
-    /// Converts a CLR reflection constructed generic full name (with assembly-qualified type arguments)
-    /// to the short canonical form: <c>Ns.Event`1[[Ns.User]]</c>.
-    /// Returns <c>null</c> if the name is not a constructed generic.
+    /// When <see cref="HandlerNode.Handles"/> was resolved to an open generic definition (e.g. <c>EntityDeletedEvent`1</c>)
+    /// but a closed <see cref="DomainEventNode"/> exists for the event type parameter from <c>IEventHandler&lt;T&gt;</c>,
+    /// remap <c>Handles</c> to the closed canonical full name so diagram edges and JSON match the event node id.
     /// </summary>
-    private static string? ToCanonicalClosedGenericFullName(string clrFullName)
+    private static void RemapEventHandlerHandlesFromIEventHandlerInterfaces(
+        List<Type> eventHandlerTypes,
+        List<DomainEventNode> domainEventNodes,
+        List<HandlerNode> eventHandlerNodes)
     {
-        var outerStart = clrFullName.IndexOf("[[", StringComparison.Ordinal);
-        if (outerStart < 0)
-            return null;
+        var eventFullNames = new HashSet<string>(domainEventNodes.Select(e => e.FullName), StringComparer.Ordinal);
+        var handlersByFullName = eventHandlerTypes.ToDictionary(t => t.FullName!, StringComparer.Ordinal);
 
-        var prefix = clrFullName[..outerStart];
-        var sb = new System.Text.StringBuilder(prefix);
-        sb.Append('[');
-
-        var i = outerStart + 1;
-        var first = true;
-        while (i < clrFullName.Length)
+        foreach (var handler in eventHandlerNodes)
         {
-            if (clrFullName[i] == '[')
+            if (!handlersByFullName.TryGetValue(handler.FullName, out var handlerType))
+                continue;
+
+            var closedFromInterfaces = new List<string>();
+            foreach (var iface in handlerType.GetInterfaces().Where(i => i.IsGenericType))
             {
-                if (!first) sb.Append(',');
-                first = false;
-                i++;
-                var commaPos = clrFullName.IndexOf(',', i);
-                var closeBracket = clrFullName.IndexOf(']', i);
-                string argFullName;
-                if (commaPos >= 0 && commaPos < closeBracket)
-                    argFullName = clrFullName[i..commaPos].Trim();
-                else if (closeBracket >= 0)
-                    argFullName = clrFullName[i..closeBracket].Trim();
-                else
-                    return null;
+                if (iface.GetGenericTypeDefinition().Name != "IEventHandler`1")
+                    continue;
 
-                sb.Append('[');
-                sb.Append(argFullName);
-                sb.Append(']');
+                var arg = iface.GetGenericArguments()[0];
+                if (arg.FullName is null || !arg.IsGenericType)
+                    continue;
 
-                var depth = 1;
-                while (i < clrFullName.Length && depth > 0)
+                var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(arg.FullName);
+                if (canonical is null || !eventFullNames.Contains(canonical))
+                    continue;
+
+                closedFromInterfaces.Add(canonical);
+            }
+
+            if (closedFromInterfaces.Count == 0)
+                continue;
+
+            for (var i = 0; i < handler.Handles.Count; i++)
+            {
+                var h = handler.Handles[i];
+                var bracket = h.IndexOf("[[", StringComparison.Ordinal);
+                if (bracket < 0)
+                    continue;
+
+                var defKey = h[..bracket];
+                foreach (var closed in closedFromInterfaces)
                 {
-                    if (clrFullName[i] == '[') depth++;
-                    else if (clrFullName[i] == ']') depth--;
-                    i++;
+                    if (closed.StartsWith(defKey, StringComparison.Ordinal) &&
+                        eventFullNames.Contains(closed))
+                    {
+                        handler.Handles[i] = closed;
+                        break;
+                    }
                 }
             }
-            else
-            {
-                i++;
-            }
         }
-
-        sb.Append(']');
-        return sb.ToString();
     }
 
     private static bool TryResolveEventNode(
@@ -1342,7 +1301,7 @@ internal sealed class AssemblyScanner
         var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
         if (bracket >= 0)
         {
-            var canonical = ToCanonicalClosedGenericFullName(typeFullName);
+            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
             if (canonical is not null && eventMap.TryGetValue(canonical, out node))
                 return true;
 

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -476,14 +476,32 @@ internal sealed class AssemblyScanner
             }
         }
 
+        var handles = handledTypes
+            .Select(NormalizeHandlerHandledTypeFullName)
+            .Where(s => s.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
         return new HandlerNode
         {
             Name = type.Name,
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
-            Handles = handledTypes.ToList()
+            Handles = handles
         };
+    }
+
+    /// <summary>
+    /// Reflection sometimes returns assembly-qualified constructed generic names; normalize to the short
+    /// canonical form used elsewhere in the graph (e.g. for record event types from <c>IEventHandler&lt;T&gt;</c>).
+    /// </summary>
+    private static string NormalizeHandlerHandledTypeFullName(string fullName)
+    {
+        if (!fullName.Contains("[[", StringComparison.Ordinal))
+            return fullName;
+
+        return GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(fullName) ?? fullName;
     }
 
     private RepositoryNode BuildRepositoryNode(Type type, List<Type> aggregateTypes, string? layer)
@@ -820,6 +838,29 @@ internal sealed class AssemblyScanner
         var emittedByMethod = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
         ScanTypeMethods(type, eventFullNames, emittedByMethod);
+
+        // Instance methods declared on base types (e.g. virtual DeleteEntity on AggregateRoot) carry IL on the
+        // declaring type — scan those bodies too so overrides in aggregates are detected.
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            foreach (var method in baseType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                if (method.IsAbstract)
+                    continue;
+
+                var impl = type.GetMethod(
+                    method.Name,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly,
+                    null,
+                    method.GetParameters().Select(p => p.ParameterType).ToArray(),
+                    null);
+                if (impl is null || impl.DeclaringType != type)
+                    continue;
+
+                var sourceMethodName = NormalizeMethodName(impl, fallbackMethodName: null);
+                ScanMethodBodyForEvents(impl, impl.Module, eventFullNames, emittedByMethod, sourceMethodName);
+            }
+        }
 
         // Also scan compiler-generated nested types (async state machines, lambda display classes, etc.)
         foreach (var nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -457,7 +457,7 @@ internal sealed class AssemblyScanner
             foreach (var arg in iface.GetGenericArguments())
             {
                 if (arg.FullName is not null)
-                    handledTypes.Add(arg.FullName);
+                    handledTypes.Add(NormalizeHandlerHandledTypeFullName(arg.FullName));
             }
         }
 
@@ -471,13 +471,12 @@ internal sealed class AssemblyScanner
                 {
                     var paramFullName = param.ParameterType.FullName;
                     if (paramFullName is not null)
-                        handledTypes.Add(paramFullName);
+                        handledTypes.Add(NormalizeHandlerHandledTypeFullName(paramFullName));
                 }
             }
         }
 
         var handles = handledTypes
-            .Select(NormalizeHandlerHandledTypeFullName)
             .Where(s => s.Length > 0)
             .Distinct(StringComparer.Ordinal)
             .ToList();
@@ -493,16 +492,10 @@ internal sealed class AssemblyScanner
     }
 
     /// <summary>
-    /// Reflection sometimes returns assembly-qualified constructed generic names; normalize to the short
-    /// canonical form used elsewhere in the graph (e.g. for record event types from <c>IEventHandler&lt;T&gt;</c>).
+    /// Reflection returns CLR <c>`1[[...]]</c> names; graph keys use bracket form <c>Type[Arg]</c>.
     /// </summary>
-    private static string NormalizeHandlerHandledTypeFullName(string fullName)
-    {
-        if (!fullName.Contains("[[", StringComparison.Ordinal))
-            return fullName;
-
-        return GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(fullName) ?? fullName;
-    }
+    private static string NormalizeHandlerHandledTypeFullName(string fullName) =>
+        GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(fullName) ?? fullName;
 
     private RepositoryNode BuildRepositoryNode(Type type, List<Type> aggregateTypes, string? layer)
     {
@@ -1115,36 +1108,31 @@ internal sealed class AssemblyScanner
     }
 
     /// <summary>
-    /// For constructed generic CLR names, the open generic definition is the prefix before type arguments (<c>[[...]]</c>).
-    /// Handlers and IL often use the constructed form while the graph node is the generic type definition.
-    /// Also matches CLR reflection names against canonical short-form constructed generics (e.g.
-    /// <c>Ns.Event`1[[Ns.User, Assembly, ...]]</c> matches <c>Ns.Event`1[[Ns.User]]</c>).
-    /// Prefers a constructed generic match over the open generic definition.
+    /// Resolves reflection or documentation type strings to graph <see cref="DomainEventNode.FullName"/> keys
+    /// (closed generics use bracket form <c>Ns.Event[Ns.Arg]</c>, not CLR <c>[[...]]</c>).
     /// </summary>
     private static string? ResolveCanonicalEventKey(string typeFullName, HashSet<string> registeredEventFullNames)
     {
         if (registeredEventFullNames.Contains(typeFullName))
             return typeFullName;
 
-        var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
-        if (bracket >= 0)
-        {
-            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
-            if (canonical is not null && registeredEventFullNames.Contains(canonical))
-                return canonical;
+        // Constructed generic (CLR `[[...]]` or bracket form): map only to the closed canonical key, never to the
+        // open generic definition — otherwise handler Handles get rewritten to `EntityDeletedEvent`1` before
+        // closed nodes exist and never match again.
+        var asClosed = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
+        if (asClosed is not null)
+            return registeredEventFullNames.Contains(asClosed) ? asClosed : null;
 
-            var def = typeFullName[..bracket];
-            if (registeredEventFullNames.Contains(def))
-                return def;
-        }
+        var defWithArity = GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(typeFullName);
+        if (defWithArity is not null && registeredEventFullNames.Contains(defWithArity))
+            return defWithArity;
 
         return null;
     }
 
     /// <summary>
-    /// Like <see cref="ResolveCanonicalEventKey"/> but prefers the constructed generic CLR name when the
-    /// open generic definition is registered, so emissions and graph edges target the closed type
-    /// (e.g. <c>EntityDeletedEvent`1[[Organization]]</c>) rather than collapsing to <c>EntityDeletedEvent`1</c>.
+    /// Like <see cref="ResolveCanonicalEventKey"/> but for IL emissions: prefer the normalized closed bracket key
+    /// when the open generic definition is registered.
     /// </summary>
     private static string? ResolveEmissionEventKey(string typeFullName, HashSet<string> registeredEventFullNames)
     {
@@ -1202,19 +1190,12 @@ internal sealed class AssemblyScanner
 
         foreach (var key in AllEmittedKeys().Distinct(StringComparer.Ordinal))
         {
-            if (!key.Contains("[[", StringComparison.Ordinal))
-                continue;
-
             var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(key);
             if (canonical is null || existingEventFullNames.Contains(canonical))
                 continue;
 
-            var bracket = canonical.IndexOf("[[", StringComparison.Ordinal);
-            if (bracket < 0)
-                continue;
-
-            var defPrefix = canonical[..bracket];
-            if (!defFullNames.Contains(defPrefix))
+            var defPrefix = GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(canonical);
+            if (defPrefix is null || !defFullNames.Contains(defPrefix))
                 continue;
 
             domainEventNodes.Add(new DomainEventNode
@@ -1279,12 +1260,33 @@ internal sealed class AssemblyScanner
             for (var i = 0; i < handler.Handles.Count; i++)
             {
                 var h = handler.Handles[i];
-                var bracket = h.IndexOf("[[", StringComparison.Ordinal);
-                var defKey = bracket >= 0 ? h[..bracket] : h;
+                var hCanon = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(h) ?? h;
+                var hOpenDef = GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(hCanon);
+                if (hOpenDef is null)
+                {
+                    var clrBi = h.IndexOf("[[", StringComparison.Ordinal);
+                    if (clrBi >= 0)
+                        hOpenDef = h[..clrBi];
+                }
+
                 foreach (var closed in closedFromInterfaces)
                 {
-                    if (closed.StartsWith(defKey, StringComparison.Ordinal) &&
-                        eventFullNames.Contains(closed))
+                    var closedOpen = GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(closed);
+                    if (closedOpen is null)
+                        continue;
+
+                    var sameOpen = hOpenDef is not null &&
+                        string.Equals(closedOpen, hOpenDef, StringComparison.Ordinal);
+                    if (!sameOpen && hOpenDef is not null)
+                    {
+                        // e.g. handler still has only arity-stripped name in edge cases
+                        sameOpen = string.Equals(
+                            GenericTypeDisplayNames.StripGenericArity(closedOpen),
+                            GenericTypeDisplayNames.StripGenericArity(hOpenDef),
+                            StringComparison.Ordinal);
+                    }
+
+                    if (sameOpen && eventFullNames.Contains(closed))
                     {
                         handler.Handles[i] = closed;
                         break;
@@ -1349,7 +1351,7 @@ internal sealed class AssemblyScanner
     {
         domainEventNodes.RemoveAll(static e =>
             e.FullName.IndexOf('`', StringComparison.Ordinal) >= 0 &&
-            e.FullName.IndexOf("[[", StringComparison.Ordinal) < 0);
+            e.FullName.IndexOf('[', StringComparison.Ordinal) < 0);
     }
 
     private static bool TryResolveEventNode(
@@ -1357,19 +1359,30 @@ internal sealed class AssemblyScanner
         string typeFullName,
         [NotNullWhen(true)] out DomainEventNode? node)
     {
+        var normalized = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName) ?? typeFullName;
+
+        if (eventMap.TryGetValue(normalized, out node))
+            return true;
+
         if (eventMap.TryGetValue(typeFullName, out node))
             return true;
 
-        var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
-        if (bracket >= 0)
+        foreach (var (key, evt) in eventMap)
         {
-            var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(typeFullName);
-            if (canonical is not null && eventMap.TryGetValue(canonical, out node))
+            if (GenericTypeDisplayNames.AreSameConstructedGeneric(typeFullName, key))
+            {
+                node = evt;
                 return true;
-
-            if (eventMap.TryGetValue(typeFullName[..bracket], out node))
-                return true;
+            }
         }
+
+        var clrBracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
+        if (clrBracket >= 0 && eventMap.TryGetValue(typeFullName[..clrBracket], out node))
+            return true;
+
+        var defArity = GenericTypeDisplayNames.GetOpenGenericDefinitionWithArity(typeFullName);
+        if (defArity is not null && eventMap.TryGetValue(defArity, out node))
+            return true;
 
         node = null;
         return false;
@@ -1786,18 +1799,19 @@ internal sealed class AssemblyScanner
             var emissions = documentationIndexer.TryGetTypeDocumentedEmissions(type);
             foreach (var (canonicalFullName, _) in emissions)
             {
-                if (!eventFullNames.Contains(canonicalFullName))
+                var fullNameKey = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(canonicalFullName) ?? canonicalFullName;
+                if (!eventFullNames.Contains(fullNameKey))
                     continue;
-                if (!emittedEvents.Contains(canonicalFullName))
-                    emittedEvents.Add(canonicalFullName);
-                if (!eventEmissions.Any(e => e.EventType == canonicalFullName))
-                    eventEmissions.Add(new EventEmissionInfo { EventType = canonicalFullName, MethodName = "(documented)" });
-                if (addedRelationships.Add((emitterFullName, canonicalFullName)))
+                if (!emittedEvents.Contains(fullNameKey))
+                    emittedEvents.Add(fullNameKey);
+                if (!eventEmissions.Any(e => e.EventType == fullNameKey))
+                    eventEmissions.Add(new EventEmissionInfo { EventType = fullNameKey, MethodName = "(documented)" });
+                if (addedRelationships.Add((emitterFullName, fullNameKey)))
                 {
                     relationships.Add(new Relationship
                     {
                         SourceType = emitterFullName,
-                        TargetType = canonicalFullName,
+                        TargetType = fullNameKey,
                         Kind = RelationshipKind.Emits,
                         Label = "emits (documented)"
                     });
@@ -1833,16 +1847,17 @@ internal sealed class AssemblyScanner
 
             foreach (var (canonicalFullName, displayName) in emissions)
             {
-                if (existingEventFullNames.Contains(canonicalFullName))
+                var fullNameKey = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(canonicalFullName) ?? canonicalFullName;
+                if (existingEventFullNames.Contains(fullNameKey))
                     continue;
 
                 domainEventNodes.Add(new DomainEventNode
                 {
                     Name = displayName,
-                    FullName = canonicalFullName,
+                    FullName = fullNameKey,
                 });
-                existingEventFullNames.Add(canonicalFullName);
-                knownDomainTypes.Add(canonicalFullName);
+                existingEventFullNames.Add(fullNameKey);
+                knownDomainTypes.Add(fullNameKey);
             }
         }
 

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -93,6 +93,14 @@ internal sealed class AssemblyScanner
                 _documentationIndexer);
         }
 
+        MergeSyntheticClosedGenericEventNodesFromEmittedKeys(
+            entityNodes,
+            aggregateNodes,
+            domainEventTypes,
+            domainEventNodes,
+            knownDomainTypes,
+            eventHandlerNodes);
+
         var commandHandlerTargetNodes = DiscoverCommandHandlerTargets(
             allTypes,
             knownDomainTypes,
@@ -175,6 +183,7 @@ internal sealed class AssemblyScanner
 
         // Wire emittedBy / handledBy on domain event nodes
         CrossReferenceEvents(domainEventNodes, entityNodes, aggregateNodes, eventHandlerNodes);
+        MergeClosedGenericHandledByOntoOpenGenericDefinition(domainEventNodes);
 
         // Detect which integration events are published by event handlers (IL scanning)
         var integrationEventFullNames = new HashSet<string>(integrationEventTypesAll.Select(e => e.FullName!));
@@ -840,12 +849,12 @@ internal sealed class AssemblyScanner
         foreach (var method in allMethods)
         {
             var methodName = NormalizeMethodName(method, fallbackMethodName: null);
-            foreach (var documentedEvent in documentationIndexer.TryGetDocumentedEmissions(declaringType, methodName))
-            {
-                var key = ResolveCanonicalEventKey(documentedEvent, eventFullNames);
-                if (key is not null)
-                    AddEventEmission(emittedByMethod, key, methodName);
-            }
+                foreach (var documentedEvent in documentationIndexer.TryGetDocumentedEmissions(declaringType, methodName))
+                {
+                    var key = ResolveCanonicalEventKey(documentedEvent, eventFullNames);
+                    if (key is not null)
+                        RecordEventEmissionForGraph(emittedByMethod, key, methodName);
+                }
         }
     }
 
@@ -919,9 +928,9 @@ internal sealed class AssemblyScanner
                 var resolved = module.ResolveMethod(token);
                 if (resolved?.DeclaringType?.FullName is { } fullName)
                 {
-                    var key = ResolveCanonicalEventKey(fullName, eventFullNames);
+                    var key = ResolveEmissionEventKey(fullName, eventFullNames);
                     if (key is not null)
-                        AddEventEmission(emittedByMethod, key, sourceMethodName);
+                        RecordEventEmissionForGraph(emittedByMethod, key, sourceMethodName);
                 }
             }
             catch
@@ -941,10 +950,10 @@ internal sealed class AssemblyScanner
     {
         if (type.FullName is not null)
         {
-            var key = ResolveCanonicalEventKey(type.FullName, eventFullNames);
+            var key = ResolveEmissionEventKey(type.FullName, eventFullNames);
             if (key is not null)
             {
-                AddEventEmission(emittedByMethod, key, sourceMethodName);
+                RecordEventEmissionForGraph(emittedByMethod, key, sourceMethodName);
                 return;
             }
         }
@@ -968,6 +977,34 @@ internal sealed class AssemblyScanner
         }
 
         methods.Add(methodName);
+    }
+
+    /// <summary>
+    /// Records an emission keyed for graph cross-reference. Constructed generic emissions are also registered
+    /// under the open generic definition so <see cref="DomainEventNode.EmittedBy"/> is populated for both nodes.
+    /// </summary>
+    private static void RecordEventEmissionForGraph(
+        Dictionary<string, HashSet<string>> emittedByMethod,
+        string resolvedKey,
+        string methodName)
+    {
+        var key = resolvedKey;
+        if (key.Contains("[[", StringComparison.Ordinal))
+        {
+            var shortForm = ToCanonicalClosedGenericFullName(key);
+            if (shortForm is not null)
+                key = shortForm;
+        }
+
+        AddEventEmission(emittedByMethod, key, methodName);
+
+        var bracket = key.IndexOf("[[", StringComparison.Ordinal);
+        if (bracket >= 0)
+        {
+            var def = key[..bracket];
+            if (!string.Equals(def, key, StringComparison.Ordinal))
+                AddEventEmission(emittedByMethod, def, methodName);
+        }
     }
 
     private static string NormalizeMethodName(MethodBase method, string? fallbackMethodName)
@@ -1030,6 +1067,35 @@ internal sealed class AssemblyScanner
     }
 
     /// <summary>
+    /// Copies <see cref="DomainEventNode.HandledBy"/> from closed-generic event nodes onto the open generic
+    /// definition node so the diagram lists all handlers in one place (e.g. Organization + Customer handlers
+    /// on <c>EntityDeletedEvent`1</c>).
+    /// </summary>
+    private static void MergeClosedGenericHandledByOntoOpenGenericDefinition(List<DomainEventNode> eventNodes)
+    {
+        var byFullName = eventNodes.ToDictionary(e => e.FullName, StringComparer.Ordinal);
+        foreach (var node in eventNodes)
+        {
+            if (node.HandledBy.Count == 0)
+                continue;
+
+            var bracket = node.FullName.IndexOf("[[", StringComparison.Ordinal);
+            if (bracket < 0)
+                continue;
+
+            var defName = node.FullName[..bracket];
+            if (!byFullName.TryGetValue(defName, out var defNode))
+                continue;
+
+            foreach (var h in node.HandledBy)
+            {
+                if (!defNode.HandledBy.Contains(h))
+                    defNode.HandledBy.Add(h);
+            }
+        }
+    }
+
+    /// <summary>
     /// For constructed generic CLR names, the open generic definition is the prefix before type arguments (<c>[[...]]</c>).
     /// Handlers and IL often use the constructed form while the graph node is the generic type definition.
     /// Also matches CLR reflection names against canonical short-form constructed generics (e.g.
@@ -1054,6 +1120,159 @@ internal sealed class AssemblyScanner
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Like <see cref="ResolveCanonicalEventKey"/> but prefers the constructed generic CLR name when the
+    /// open generic definition is registered, so emissions and graph edges target the closed type
+    /// (e.g. <c>EntityDeletedEvent`1[[Organization]]</c>) rather than collapsing to <c>EntityDeletedEvent`1</c>.
+    /// </summary>
+    private static string? ResolveEmissionEventKey(string typeFullName, HashSet<string> registeredEventFullNames)
+    {
+        if (registeredEventFullNames.Contains(typeFullName))
+            return typeFullName;
+
+        var bracket = typeFullName.IndexOf("[[", StringComparison.Ordinal);
+        if (bracket >= 0)
+        {
+            var canonical = ToCanonicalClosedGenericFullName(typeFullName);
+            if (canonical is not null && registeredEventFullNames.Contains(canonical))
+                return canonical;
+
+            var def = typeFullName[..bracket];
+            if (registeredEventFullNames.Contains(def))
+                return typeFullName;
+        }
+
+        return ResolveCanonicalEventKey(typeFullName, registeredEventFullNames);
+    }
+
+    /// <summary>
+    /// Builds a C#-style display name (e.g. <c>EntityDeletedEvent&lt;Organization&gt;</c>) from a short canonical
+    /// constructed generic <see cref="Type.FullName"/> such as <c>Ns.EntityDeletedEvent`1[[Ns.Organization]]</c>.
+    /// </summary>
+    private static string FormatClosedGenericDisplayName(string canonicalConstructedClrFullName)
+    {
+        var tick = canonicalConstructedClrFullName.IndexOf('`');
+        if (tick < 0)
+            return canonicalConstructedClrFullName;
+
+        var defFqn = canonicalConstructedClrFullName[..tick];
+        var simpleDef = defFqn.Contains('.', StringComparison.Ordinal)
+            ? defFqn[(defFqn.LastIndexOf('.') + 1)..]
+            : defFqn;
+
+        var innerStart = canonicalConstructedClrFullName.IndexOf("[[", StringComparison.Ordinal);
+        if (innerStart < 0)
+            return StripGenericArity(simpleDef);
+
+        var args = new List<string>();
+        var i = innerStart + 1;
+        while (i < canonicalConstructedClrFullName.Length)
+        {
+            if (canonicalConstructedClrFullName[i] != '[')
+            {
+                i++;
+                continue;
+            }
+
+            i++;
+            var argStart = i;
+            var depth = 1;
+            while (i < canonicalConstructedClrFullName.Length && depth > 0)
+            {
+                if (canonicalConstructedClrFullName[i] == '[') depth++;
+                else if (canonicalConstructedClrFullName[i] == ']') depth--;
+                i++;
+            }
+
+            var argSegment = canonicalConstructedClrFullName[argStart..(i - 1)];
+            var comma = argSegment.IndexOf(',', StringComparison.Ordinal);
+            var argType = (comma >= 0 ? argSegment[..comma] : argSegment).Trim();
+            var shortArg = argType.Contains('.', StringComparison.Ordinal)
+                ? argType[(argType.LastIndexOf('.') + 1)..]
+                : argType;
+            args.Add(shortArg);
+
+            if (i < canonicalConstructedClrFullName.Length && canonicalConstructedClrFullName[i] == ',')
+                i++;
+        }
+
+        return args.Count == 0
+            ? StripGenericArity(simpleDef)
+            : $"{StripGenericArity(simpleDef)}<{string.Join(", ", args)}>";
+    }
+
+    /// <summary>
+    /// Ensures each distinct closed-generic emission key (from IL) has a <see cref="DomainEventNode"/> with a
+    /// C#-style <see cref="DomainEventNode.Name"/>, and remaps handler <c>Handles</c> to that canonical key when applicable.
+    /// </summary>
+    private static void MergeSyntheticClosedGenericEventNodesFromEmittedKeys(
+        List<EntityNode> entityNodes,
+        List<AggregateNode> aggregateNodes,
+        List<Type> domainEventDefinitions,
+        List<DomainEventNode> domainEventNodes,
+        HashSet<string> knownDomainTypes,
+        List<HandlerNode> eventHandlerNodes)
+    {
+        var existingEventFullNames = new HashSet<string>(domainEventNodes.Select(e => e.FullName), StringComparer.Ordinal);
+        var defFullNames = new HashSet<string>(domainEventDefinitions.Select(t => t.FullName!), StringComparer.Ordinal);
+
+        IEnumerable<string> AllEmittedKeys()
+        {
+            foreach (var n in entityNodes)
+            {
+                foreach (var e in n.EmittedEvents)
+                    yield return e;
+                foreach (var em in n.EventEmissions)
+                    yield return em.EventType;
+            }
+
+            foreach (var n in aggregateNodes)
+            {
+                foreach (var e in n.EmittedEvents)
+                    yield return e;
+                foreach (var em in n.EventEmissions)
+                    yield return em.EventType;
+            }
+        }
+
+        foreach (var key in AllEmittedKeys().Distinct(StringComparer.Ordinal))
+        {
+            if (!key.Contains("[[", StringComparison.Ordinal))
+                continue;
+
+            var canonical = ToCanonicalClosedGenericFullName(key);
+            if (canonical is null || existingEventFullNames.Contains(canonical))
+                continue;
+
+            var bracket = canonical.IndexOf("[[", StringComparison.Ordinal);
+            if (bracket < 0)
+                continue;
+
+            var defPrefix = canonical[..bracket];
+            if (!defFullNames.Contains(defPrefix))
+                continue;
+
+            domainEventNodes.Add(new DomainEventNode
+            {
+                Name = FormatClosedGenericDisplayName(canonical),
+                FullName = canonical,
+            });
+            existingEventFullNames.Add(canonical);
+            knownDomainTypes.Add(canonical);
+        }
+
+        var eventFullNames = new HashSet<string>(existingEventFullNames, StringComparer.Ordinal);
+        foreach (var handler in eventHandlerNodes)
+        {
+            for (var i = 0; i < handler.Handles.Count; i++)
+            {
+                var resolved = ResolveCanonicalEventKey(handler.Handles[i], eventFullNames);
+                if (resolved is not null)
+                    handler.Handles[i] = resolved;
+            }
+        }
     }
 
     /// <summary>

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -102,7 +102,11 @@ internal sealed class AssemblyScanner
             knownDomainTypes,
             eventHandlerNodes);
 
+        EnsureClosedGenericDomainEventNodesFromEventHandlers(domainEventTypes, domainEventNodes, knownDomainTypes, eventHandlerTypes);
+
         RemapEventHandlerHandlesFromIEventHandlerInterfaces(eventHandlerTypes, domainEventNodes, eventHandlerNodes);
+
+        RemoveOpenGenericDomainEventDefinitionNodes(domainEventNodes);
 
         var commandHandlerTargetNodes = DiscoverCommandHandlerTargets(
             allTypes,
@@ -186,7 +190,6 @@ internal sealed class AssemblyScanner
 
         // Wire emittedBy / handledBy on domain event nodes
         CrossReferenceEvents(domainEventNodes, entityNodes, aggregateNodes, eventHandlerNodes);
-        MergeClosedGenericHandledByOntoOpenGenericDefinition(domainEventNodes);
 
         // Detect which integration events are published by event handlers (IL scanning)
         var integrationEventFullNames = new HashSet<string>(integrationEventTypesAll.Select(e => e.FullName!));
@@ -1009,14 +1012,6 @@ internal sealed class AssemblyScanner
         }
 
         AddEventEmission(emittedByMethod, key, methodName);
-
-        var bracket = key.IndexOf("[[", StringComparison.Ordinal);
-        if (bracket >= 0)
-        {
-            var def = key[..bracket];
-            if (!string.Equals(def, key, StringComparison.Ordinal))
-                AddEventEmission(emittedByMethod, def, methodName);
-        }
     }
 
     private static string NormalizeMethodName(MethodBase method, string? fallbackMethodName)
@@ -1074,35 +1069,6 @@ internal sealed class AssemblyScanner
             {
                 if (TryResolveEventNode(eventMap, handled, out var evtNode))
                     evtNode.HandledBy.Add(handler.FullName);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Copies <see cref="DomainEventNode.HandledBy"/> from closed-generic event nodes onto the open generic
-    /// definition node so the diagram lists all handlers in one place (e.g. Organization + Customer handlers
-    /// on <c>EntityDeletedEvent`1</c>).
-    /// </summary>
-    private static void MergeClosedGenericHandledByOntoOpenGenericDefinition(List<DomainEventNode> eventNodes)
-    {
-        var byFullName = eventNodes.ToDictionary(e => e.FullName, StringComparer.Ordinal);
-        foreach (var node in eventNodes)
-        {
-            if (node.HandledBy.Count == 0)
-                continue;
-
-            var bracket = node.FullName.IndexOf("[[", StringComparison.Ordinal);
-            if (bracket < 0)
-                continue;
-
-            var defName = node.FullName[..bracket];
-            if (!byFullName.TryGetValue(defName, out var defNode))
-                continue;
-
-            foreach (var h in node.HandledBy)
-            {
-                if (!defNode.HandledBy.Contains(h))
-                    defNode.HandledBy.Add(h);
             }
         }
     }
@@ -1273,10 +1239,7 @@ internal sealed class AssemblyScanner
             {
                 var h = handler.Handles[i];
                 var bracket = h.IndexOf("[[", StringComparison.Ordinal);
-                if (bracket < 0)
-                    continue;
-
-                var defKey = h[..bracket];
+                var defKey = bracket >= 0 ? h[..bracket] : h;
                 foreach (var closed in closedFromInterfaces)
                 {
                     if (closed.StartsWith(defKey, StringComparison.Ordinal) &&
@@ -1288,6 +1251,64 @@ internal sealed class AssemblyScanner
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Ensures a <see cref="DomainEventNode"/> exists for each closed generic event type referenced by
+    /// <c>IEventHandler&lt;T&gt;</c>, so removing open generic definition nodes does not drop handlers.
+    /// </summary>
+    private static void EnsureClosedGenericDomainEventNodesFromEventHandlers(
+        List<Type> domainEventDefinitions,
+        List<DomainEventNode> domainEventNodes,
+        HashSet<string> knownDomainTypes,
+        List<Type> eventHandlerTypes)
+    {
+        var defsByFullName = domainEventDefinitions
+            .Where(t => t is { FullName: not null, IsGenericTypeDefinition: true })
+            .Select(t => t.FullName!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var existing = new HashSet<string>(domainEventNodes.Select(e => e.FullName), StringComparer.Ordinal);
+
+        foreach (var handlerType in eventHandlerTypes)
+        {
+            foreach (var iface in handlerType.GetInterfaces().Where(i => i.IsGenericType))
+            {
+                if (iface.GetGenericTypeDefinition().Name != "IEventHandler`1")
+                    continue;
+
+                var arg = iface.GetGenericArguments()[0];
+                if (arg.FullName is null || !arg.IsGenericType || arg.IsGenericTypeDefinition)
+                    continue;
+
+                var defFullName = arg.GetGenericTypeDefinition().FullName;
+                if (defFullName is null || !defsByFullName.Contains(defFullName))
+                    continue;
+
+                var canonical = GenericTypeDisplayNames.ToCanonicalClosedGenericFullName(arg.FullName);
+                if (canonical is null || existing.Contains(canonical))
+                    continue;
+
+                domainEventNodes.Add(new DomainEventNode
+                {
+                    Name = GenericTypeDisplayNames.FormatAsCSharp(canonical),
+                    FullName = canonical,
+                });
+                existing.Add(canonical);
+                knownDomainTypes.Add(canonical);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops open generic definition nodes (e.g. <c>EntityDeletedEvent`1</c>) from the listed domain events;
+    /// only closed constructed types (and non-generics) remain as first-class graph nodes.
+    /// </summary>
+    private static void RemoveOpenGenericDomainEventDefinitionNodes(List<DomainEventNode> domainEventNodes)
+    {
+        domainEventNodes.RemoveAll(static e =>
+            e.FullName.IndexOf('`', StringComparison.Ordinal) >= 0 &&
+            e.FullName.IndexOf("[[", StringComparison.Ordinal) < 0);
     }
 
     private static bool TryResolveEventNode(

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -50,14 +50,28 @@ internal sealed class AssemblyScanner
 
         bool OwnedElsewhere(Type t) => _config.ExternallyOwnedSharedAssemblies.Contains(t.Assembly);
 
-        // Categorize types based on configured conventions (types "owned" by another BC are scanned but not listed here)
+        // Categorize types based on configured conventions. Types in ExternallyOwnedSharedAssemblies are still
+        // scanned for IL and references; domain events (and handler types for generic resolution) that match
+        // conventions there are merged into discovery so emissions and IEventHandler<T> remapping work.
         var entityTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.EntityConvention.Matches(t)).ToList();
         var aggregateTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.AggregateConvention.Matches(t)).ToList();
         var valueObjectTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.ValueObjectConvention.Matches(t)).ToList();
         var domainEventTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.DomainEventConvention.Matches(t)).ToList();
+        var externallyOwnedDomainEventTypes = allTypes.Where(t => OwnedElsewhere(t) && _config.DomainEventConvention.Matches(t)).ToList();
+        var domainEventTypesForScan = domainEventTypes
+            .Concat(externallyOwnedDomainEventTypes)
+            .GroupBy(t => t.FullName!, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .ToList();
         var integrationEventTypesAll = allTypes.Where(t => _config.IntegrationEventConvention.Matches(t)).ToList();
         var integrationEventTypes = integrationEventTypesAll.Where(t => !OwnedElsewhere(t)).ToList();
         var eventHandlerTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.EventHandlerConvention.Matches(t)).ToList();
+        var externallyOwnedEventHandlerTypes = allTypes.Where(t => OwnedElsewhere(t) && _config.EventHandlerConvention.Matches(t)).ToList();
+        var eventHandlerTypesForResolution = eventHandlerTypes
+            .Concat(externallyOwnedEventHandlerTypes)
+            .GroupBy(t => t.FullName!, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .ToList();
         var commandHandlerTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.CommandHandlerConvention.Matches(t)).ToList();
         var queryHandlerTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.QueryHandlerConvention.Matches(t)).ToList();
         var repositoryTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.RepositoryConvention.Matches(t)).ToList();
@@ -66,15 +80,15 @@ internal sealed class AssemblyScanner
         // Build a set of all "known domain type" full names for reference detection
         var knownDomainTypes = new HashSet<string>(
             entityTypes.Concat(aggregateTypes).Concat(valueObjectTypes)
-                .Concat(domainEventTypes).Concat(integrationEventTypesAll)
+                .Concat(domainEventTypes).Concat(externallyOwnedDomainEventTypes).Concat(integrationEventTypesAll)
                 .Select(t => t.FullName!)
                 .Where(n => n is not null));
 
         // Build nodes
-        var entityNodes = entityTypes.Select(t => BuildEntityNode(t, domainEventTypes, knownDomainTypes, _config.GetLayer(t))).ToList();
-        var aggregateNodes = aggregateTypes.Select(t => BuildAggregateNode(t, entityTypes, domainEventTypes, knownDomainTypes, _config.GetLayer(t))).ToList();
+        var entityNodes = entityTypes.Select(t => BuildEntityNode(t, domainEventTypesForScan, knownDomainTypes, _config.GetLayer(t))).ToList();
+        var aggregateNodes = aggregateTypes.Select(t => BuildAggregateNode(t, entityTypes, domainEventTypesForScan, knownDomainTypes, _config.GetLayer(t))).ToList();
         var valueObjectNodes = valueObjectTypes.Select(t => BuildValueObjectNode(t, knownDomainTypes, _config.GetLayer(t))).ToList();
-        var domainEventNodes = domainEventTypes.Select(t => BuildDomainEventNode(t, knownDomainTypes, _config.GetLayer(t))).ToList();
+        var domainEventNodes = domainEventTypesForScan.Select(t => BuildDomainEventNode(t, knownDomainTypes, _config.GetLayer(t))).ToList();
         var integrationEventNodes = integrationEventTypes.Select(t => BuildDomainEventNode(t, knownDomainTypes, _config.GetLayer(t))).ToList();
 
         var eventHandlerNodes = eventHandlerTypes.Select(t => BuildHandlerNode(t, knownDomainTypes, _config.GetLayer(t))).ToList();
@@ -97,14 +111,14 @@ internal sealed class AssemblyScanner
         MergeSyntheticClosedGenericEventNodesFromEmittedKeys(
             entityNodes,
             aggregateNodes,
-            domainEventTypes,
+            domainEventTypesForScan,
             domainEventNodes,
             knownDomainTypes,
             eventHandlerNodes);
 
-        EnsureClosedGenericDomainEventNodesFromEventHandlers(domainEventTypes, domainEventNodes, knownDomainTypes, eventHandlerTypes);
+        EnsureClosedGenericDomainEventNodesFromEventHandlers(domainEventTypesForScan, domainEventNodes, knownDomainTypes, eventHandlerTypesForResolution);
 
-        RemapEventHandlerHandlesFromIEventHandlerInterfaces(eventHandlerTypes, domainEventNodes, eventHandlerNodes);
+        RemapEventHandlerHandlesFromIEventHandlerInterfaces(eventHandlerTypesForResolution, domainEventNodes, eventHandlerNodes);
 
         RemoveOpenGenericDomainEventDefinitionNodes(domainEventNodes);
 

--- a/DomainModeling/Discovery/RoslynDocumentationIndexer.cs
+++ b/DomainModeling/Discovery/RoslynDocumentationIndexer.cs
@@ -687,8 +687,8 @@ internal sealed partial class RoslynDocumentationIndexer
     /// <summary>
     /// Builds a canonical CLR full name that matches the format produced by <c>Type.FullName</c> for
     /// constructed generic types: <c>Ns.EntityDeletedEvent`1[[Ns.User, AssemblyName, ...]]</c>.
+    /// The graph later normalizes these to bracket keys via <see cref="GenericTypeDisplayNames.ToCanonicalClosedGenericFullName"/>.
     /// For non-generic types this is equivalent to <see cref="ToClrMetadataFullName"/>.
-    /// For constructed generics this uses the bracket notation matching CLR reflection.
     /// </summary>
     internal static string ToCanonicalGenericFullName(INamedTypeSymbol symbol)
     {

--- a/DomainModeling/GenericTypeDisplayNames.cs
+++ b/DomainModeling/GenericTypeDisplayNames.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DomainModeling;
 
 /// <summary>
-/// Shared helpers for CLR generic type names: short canonical forms and C#-style display names.
-/// Used by the assembly scanner and any API surface that should show <c>MyEvent&lt;T&gt;</c> instead of <c>MyEvent`1</c>.
+/// Shared helpers for generic domain type keys and C#-style display names.
+/// Closed constructed types use bracket notation: <c>Ns.MyEvent[Ns.MyEntity]</c> (not CLR <c>MyEvent`1[[Ns.MyEntity]]</c>).
 /// </summary>
 public static class GenericTypeDisplayNames
 {
@@ -18,114 +19,178 @@ public static class GenericTypeDisplayNames
     }
 
     /// <summary>
-    /// Converts a CLR reflection constructed generic full name (possibly with assembly-qualified type arguments)
-    /// to the short canonical form: <c>Ns.Event`1[[Ns.User]]</c>.
+    /// Converts a CLR reflection constructed generic name (with <c>[[...]]</c>) or an existing bracket form
+    /// to the canonical key: <c>Ns.Event[Ns.Arg1, Ns.Arg2]</c> (no <c>`n</c>, no double brackets).
     /// Returns <c>null</c> if the name is not a constructed generic.
     /// </summary>
     public static string? ToCanonicalClosedGenericFullName(string clrFullName)
+    {
+        if (string.IsNullOrEmpty(clrFullName))
+            return null;
+
+        if (clrFullName.Contains("[[", StringComparison.Ordinal))
+            return FromClrDoubleBracketForm(clrFullName);
+
+        // Bracket form: Ns.Event[Ns.Arg] (no CLR double brackets)
+        if (clrFullName.Length >= 3 && clrFullName[^1] == ']')
+        {
+            var open = clrFullName.LastIndexOf('[');
+            if (open > 0)
+                return NormalizeBracketForm(clrFullName, open);
+        }
+
+        return null;
+    }
+
+    private static string? FromClrDoubleBracketForm(string clrFullName)
     {
         var outerStart = clrFullName.IndexOf("[[", StringComparison.Ordinal);
         if (outerStart < 0)
             return null;
 
-        var prefix = clrFullName[..outerStart];
-        var sb = new System.Text.StringBuilder(prefix);
-        sb.Append('[');
+        var defWithArity = clrFullName[..outerStart];
+        var defStripped = StripGenericArity(defWithArity);
+        var args = new List<string>();
 
         var i = outerStart + 1;
-        var first = true;
         while (i < clrFullName.Length)
         {
-            if (clrFullName[i] == '[')
-            {
-                if (!first) sb.Append(',');
-                first = false;
-                i++;
-                var commaPos = clrFullName.IndexOf(',', i);
-                var closeBracket = clrFullName.IndexOf(']', i);
-                string argFullName;
-                if (commaPos >= 0 && commaPos < closeBracket)
-                    argFullName = clrFullName[i..commaPos].Trim();
-                else if (closeBracket >= 0)
-                    argFullName = clrFullName[i..closeBracket].Trim();
-                else
-                    return null;
-
-                sb.Append('[');
-                sb.Append(argFullName);
-                sb.Append(']');
-
-                var depth = 1;
-                while (i < clrFullName.Length && depth > 0)
-                {
-                    if (clrFullName[i] == '[') depth++;
-                    else if (clrFullName[i] == ']') depth--;
-                    i++;
-                }
-            }
-            else
-            {
-                i++;
-            }
-        }
-
-        sb.Append(']');
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Builds a C#-style display name (e.g. <c>EntityDeletedEvent&lt;Organization&gt;</c>) from a short canonical
-    /// constructed generic CLR name such as <c>Ns.EntityDeletedEvent`1[[Ns.Organization]]</c>.
-    /// </summary>
-    public static string FormatAsCSharp(string canonicalConstructedClrFullName)
-    {
-        var tick = canonicalConstructedClrFullName.IndexOf('`', StringComparison.Ordinal);
-        if (tick < 0)
-            return canonicalConstructedClrFullName;
-
-        var defFqn = canonicalConstructedClrFullName[..tick];
-        var simpleDef = defFqn.Contains('.', StringComparison.Ordinal)
-            ? defFqn[(defFqn.LastIndexOf('.') + 1)..]
-            : defFqn;
-
-        var innerStart = canonicalConstructedClrFullName.IndexOf("[[", StringComparison.Ordinal);
-        if (innerStart < 0)
-            return StripGenericArity(simpleDef);
-
-        var args = new List<string>();
-        var i = innerStart + 1;
-        while (i < canonicalConstructedClrFullName.Length)
-        {
-            if (canonicalConstructedClrFullName[i] != '[')
+            if (clrFullName[i] != '[')
             {
                 i++;
                 continue;
             }
 
             i++;
-            var argStart = i;
+            var commaPos = clrFullName.IndexOf(',', i);
+            var closeBracket = clrFullName.IndexOf(']', i);
+            string argFullName;
+            if (commaPos >= 0 && closeBracket >= 0 && commaPos < closeBracket)
+                argFullName = clrFullName[i..commaPos].Trim();
+            else if (closeBracket >= 0)
+                argFullName = clrFullName[i..closeBracket].Trim();
+            else
+                return null;
+
+            args.Add(argFullName);
+
             var depth = 1;
-            while (i < canonicalConstructedClrFullName.Length && depth > 0)
+            while (i < clrFullName.Length && depth > 0)
             {
-                if (canonicalConstructedClrFullName[i] == '[') depth++;
-                else if (canonicalConstructedClrFullName[i] == ']') depth--;
+                if (clrFullName[i] == '[') depth++;
+                else if (clrFullName[i] == ']') depth--;
                 i++;
             }
-
-            var argSegment = canonicalConstructedClrFullName[argStart..(i - 1)];
-            var comma = argSegment.IndexOf(',', StringComparison.Ordinal);
-            var argType = (comma >= 0 ? argSegment[..comma] : argSegment).Trim();
-            var shortArg = argType.Contains('.', StringComparison.Ordinal)
-                ? argType[(argType.LastIndexOf('.') + 1)..]
-                : argType;
-            args.Add(shortArg);
-
-            if (i < canonicalConstructedClrFullName.Length && canonicalConstructedClrFullName[i] == ',')
-                i++;
         }
 
-        return args.Count == 0
-            ? StripGenericArity(simpleDef)
-            : $"{StripGenericArity(simpleDef)}<{string.Join(", ", args)}>";
+        if (args.Count == 0)
+            return null;
+
+        return defStripped + "[" + string.Join(", ", args.Select(StripAssemblyQualifier)) + "]";
+    }
+
+    private static string NormalizeBracketForm(string fullName, int argsOpenBracket)
+    {
+        var def = fullName[..argsOpenBracket];
+        var inner = fullName[(argsOpenBracket + 1)..^1];
+        var args = SplitTopLevelCommaSeparated(inner);
+        return def + "[" + string.Join(", ", args.Select(a => StripAssemblyQualifier(a.Trim()))) + "]";
+    }
+
+    private static List<string> SplitTopLevelCommaSeparated(string inner)
+    {
+        var parts = new List<string>();
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < inner.Length; i++)
+        {
+            var c = inner[i];
+            if (c == '[' || c == '<') depth++;
+            else if (c == ']' || c == '>') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                parts.Add(inner[start..i]);
+                start = i + 1;
+            }
+        }
+
+        parts.Add(inner[start..]);
+        return parts;
+    }
+
+    private static string StripAssemblyQualifier(string typeNameWithOptionalAssembly)
+    {
+        var comma = typeNameWithOptionalAssembly.IndexOf(',', StringComparison.Ordinal);
+        return comma >= 0 ? typeNameWithOptionalAssembly[..comma].Trim() : typeNameWithOptionalAssembly.Trim();
+    }
+
+    /// <summary>
+    /// True if both strings refer to the same constructed generic (after normalizing CLR vs bracket forms).
+    /// </summary>
+    public static bool AreSameConstructedGeneric(string? a, string? b)
+    {
+        if (a is null || b is null)
+            return false;
+        if (string.Equals(a, b, StringComparison.Ordinal))
+            return true;
+
+        var ca = ToCanonicalClosedGenericFullName(a);
+        var cb = ToCanonicalClosedGenericFullName(b);
+        return ca is not null && cb is not null && string.Equals(ca, cb, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns the open generic definition full name (with <c>`n</c> arity) for a closed generic key,
+    /// e.g. <c>Ns.EntityDeletedEvent[Ns.C]</c> → <c>Ns.EntityDeletedEvent`1</c>.
+    /// </summary>
+    public static string? GetOpenGenericDefinitionWithArity(string closedOrClrFullName)
+    {
+        var canon = ToCanonicalClosedGenericFullName(closedOrClrFullName);
+        if (canon is null || canon[^1] != ']')
+            return null;
+
+        var openBracket = canon.IndexOf('[', StringComparison.Ordinal);
+        if (openBracket < 0)
+            return null;
+
+        var defPart = canon[..openBracket];
+        if (defPart.IndexOf('`', StringComparison.Ordinal) >= 0)
+            return defPart;
+
+        var inner = canon[(openBracket + 1)..^1];
+        var arity = SplitTopLevelCommaSeparated(inner).Count;
+        return arity > 0 ? $"{defPart}`{arity}" : null;
+    }
+
+    /// <summary>
+    /// Builds a C#-style display name (e.g. <c>EntityDeletedEvent&lt;Customer&gt;</c>) from a canonical
+    /// bracket key such as <c>Ns.EntityDeletedEvent[Ns.Customer]</c>.
+    /// </summary>
+    public static string FormatAsCSharp(string canonicalBracketFullName)
+    {
+        var normalized = ToCanonicalClosedGenericFullName(canonicalBracketFullName) ?? canonicalBracketFullName;
+
+        var open = normalized.LastIndexOf('[');
+        if (open < 0 || normalized[^1] != ']')
+            return normalized;
+
+        var defFqn = StripGenericArity(normalized[..open]);
+        var simpleDef = defFqn.Contains('.', StringComparison.Ordinal)
+            ? defFqn[(defFqn.LastIndexOf('.') + 1)..]
+            : defFqn;
+
+        var inner = normalized[(open + 1)..^1];
+        var args = SplitTopLevelCommaSeparated(inner);
+        var shortArgs = args.Select(a =>
+        {
+            var t = a.Trim();
+            return t.Contains('.', StringComparison.Ordinal)
+                ? t[(t.LastIndexOf('.') + 1)..]
+                : t;
+        }).ToList();
+
+        return shortArgs.Count == 0
+            ? simpleDef
+            : $"{simpleDef}<{string.Join(", ", shortArgs)}>";
     }
 }

--- a/DomainModeling/GenericTypeDisplayNames.cs
+++ b/DomainModeling/GenericTypeDisplayNames.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+
+namespace DomainModeling;
+
+/// <summary>
+/// Shared helpers for CLR generic type names: short canonical forms and C#-style display names.
+/// Used by the assembly scanner and any API surface that should show <c>MyEvent&lt;T&gt;</c> instead of <c>MyEvent`1</c>.
+/// </summary>
+public static class GenericTypeDisplayNames
+{
+    /// <summary>
+    /// Strips the <c>`n</c> arity suffix from a metadata type name fragment.
+    /// </summary>
+    public static string StripGenericArity(string name)
+    {
+        var idx = name.IndexOf('`', StringComparison.Ordinal);
+        return idx >= 0 ? name[..idx] : name;
+    }
+
+    /// <summary>
+    /// Converts a CLR reflection constructed generic full name (possibly with assembly-qualified type arguments)
+    /// to the short canonical form: <c>Ns.Event`1[[Ns.User]]</c>.
+    /// Returns <c>null</c> if the name is not a constructed generic.
+    /// </summary>
+    public static string? ToCanonicalClosedGenericFullName(string clrFullName)
+    {
+        var outerStart = clrFullName.IndexOf("[[", StringComparison.Ordinal);
+        if (outerStart < 0)
+            return null;
+
+        var prefix = clrFullName[..outerStart];
+        var sb = new System.Text.StringBuilder(prefix);
+        sb.Append('[');
+
+        var i = outerStart + 1;
+        var first = true;
+        while (i < clrFullName.Length)
+        {
+            if (clrFullName[i] == '[')
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                i++;
+                var commaPos = clrFullName.IndexOf(',', i);
+                var closeBracket = clrFullName.IndexOf(']', i);
+                string argFullName;
+                if (commaPos >= 0 && commaPos < closeBracket)
+                    argFullName = clrFullName[i..commaPos].Trim();
+                else if (closeBracket >= 0)
+                    argFullName = clrFullName[i..closeBracket].Trim();
+                else
+                    return null;
+
+                sb.Append('[');
+                sb.Append(argFullName);
+                sb.Append(']');
+
+                var depth = 1;
+                while (i < clrFullName.Length && depth > 0)
+                {
+                    if (clrFullName[i] == '[') depth++;
+                    else if (clrFullName[i] == ']') depth--;
+                    i++;
+                }
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds a C#-style display name (e.g. <c>EntityDeletedEvent&lt;Organization&gt;</c>) from a short canonical
+    /// constructed generic CLR name such as <c>Ns.EntityDeletedEvent`1[[Ns.Organization]]</c>.
+    /// </summary>
+    public static string FormatAsCSharp(string canonicalConstructedClrFullName)
+    {
+        var tick = canonicalConstructedClrFullName.IndexOf('`', StringComparison.Ordinal);
+        if (tick < 0)
+            return canonicalConstructedClrFullName;
+
+        var defFqn = canonicalConstructedClrFullName[..tick];
+        var simpleDef = defFqn.Contains('.', StringComparison.Ordinal)
+            ? defFqn[(defFqn.LastIndexOf('.') + 1)..]
+            : defFqn;
+
+        var innerStart = canonicalConstructedClrFullName.IndexOf("[[", StringComparison.Ordinal);
+        if (innerStart < 0)
+            return StripGenericArity(simpleDef);
+
+        var args = new List<string>();
+        var i = innerStart + 1;
+        while (i < canonicalConstructedClrFullName.Length)
+        {
+            if (canonicalConstructedClrFullName[i] != '[')
+            {
+                i++;
+                continue;
+            }
+
+            i++;
+            var argStart = i;
+            var depth = 1;
+            while (i < canonicalConstructedClrFullName.Length && depth > 0)
+            {
+                if (canonicalConstructedClrFullName[i] == '[') depth++;
+                else if (canonicalConstructedClrFullName[i] == ']') depth--;
+                i++;
+            }
+
+            var argSegment = canonicalConstructedClrFullName[argStart..(i - 1)];
+            var comma = argSegment.IndexOf(',', StringComparison.Ordinal);
+            var argType = (comma >= 0 ? argSegment[..comma] : argSegment).Trim();
+            var shortArg = argType.Contains('.', StringComparison.Ordinal)
+                ? argType[(argType.LastIndexOf('.') + 1)..]
+                : argType;
+            args.Add(shortArg);
+
+            if (i < canonicalConstructedClrFullName.Length && canonicalConstructedClrFullName[i] == ',')
+                i++;
+        }
+
+        return args.Count == 0
+            ? StripGenericArity(simpleDef)
+            : $"{StripGenericArity(simpleDef)}<{string.Join(", ", args)}>";
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closed constructed generic domain events use bracket keys (`Type[Arg]`). This PR also merges **domain event types** (and **handler types for generic resolution**) from **externally owned shared assemblies** when they match conventions, so IL emission detection and `IEventHandler<T>` remapping work for shared-kernel events.

## Changes

- **Bracket canonical keys** for closed generics in the graph.
- **Shared assembly merge**: `domainEventTypesForScan` = local domain events ∪ convention-matching types from `ExternallyOwnedSharedAssemblies` (deduped by `FullName`). Same idea for `eventHandlerTypesForResolution` (handlers still listed only from the local BC; shared handlers help close generic `Handles` when needed).
- **Regression**: `SharedOnlyCatalogEvent` defined only in `DomainModeling.Example.Shared`, emitted from `Product.TestForMe`, with `ExampleAppGraphTests` assertion.

## Verification

`dotnet test` (71 tests) passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70b025c5-7e84-46ab-963a-c4f7e19056fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70b025c5-7e84-46ab-963a-c4f7e19056fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

