### PR TITLE
Discover domain events from handler method parameter types

### DIFF
--- a/DomainModeling.Tests/DDDBuilderTests.cs
+++ b/DomainModeling.Tests/DDDBuilderTests.cs
@@ -598,6 +598,44 @@ public class DDDBuilderTests
     }
 
     [Fact]
+    public void Build_DomainEvents_StructuralConvention_DiscoversEventFromHandleParameter()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var graph = DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .WithApplicationAssembly(assembly)
+                .EventHandlers(h => h.NameEndsWith("EventHandler"))
+                .DomainEvents(e => e
+                    .Type(t => t.NameEndsWith("EventHandler"))
+                    .HasMethod("Handle")
+                    .Parameters()
+                    .First()
+                    .Type()))
+            .Build();
+
+        var ctx = graph.BoundedContexts.Single();
+        ctx.DomainEvents.Should().Contain(e => e.Name == "CustomerCreatedEvent");
+        ctx.EventHandlers.Should().Contain(h => h.Name == "PublishCustomerRegisteredWhenCreatedEventHandler");
+    }
+
+    [Fact]
+    public void DomainEvents_Type_WithoutNestedPredicates_Throws()
+    {
+        var assembly = typeof(Order).Assembly;
+
+        var act = () => DDDBuilder.Create()
+            .WithBoundedContext("Sales", ctx => ctx
+                .WithDomainAssembly(assembly)
+                .DomainEvents(e => e.Type(_ => { })))
+            .Build();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*at least one predicate*");
+    }
+
+    [Fact]
     public void Build_EventHandlers_AndConvention_RequiresAllPredicatesInBranch()
     {
         var assembly = typeof(Order).Assembly;

--- a/DomainModeling/Builder/StructuralDomainEventRule.cs
+++ b/DomainModeling/Builder/StructuralDomainEventRule.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+
+namespace DomainModeling.Builder;
+
+/// <summary>
+/// Describes how to derive domain event types from handler types (e.g. first parameter of <c>Handle</c>).
+/// </summary>
+internal sealed class StructuralDomainEventRule(TypeConventionBuilder rootMatcher, string methodName, int parameterIndex)
+{
+    public TypeConventionBuilder RootMatcher { get; } = rootMatcher;
+    public string MethodName { get; } = methodName;
+    public int ParameterIndex { get; } = parameterIndex;
+
+    /// <summary>
+    /// Yields non-null parameter types from matching roots that have a suitable method.
+    /// </summary>
+    public IEnumerable<Type> EnumerateEventTypes(IEnumerable<Type> candidateRoots)
+    {
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        foreach (var root in candidateRoots)
+        {
+            if (!RootMatcher.Matches(root))
+                continue;
+
+            var methods = root.GetMethods(flags).Where(m => string.Equals(m.Name, MethodName, StringComparison.Ordinal));
+            foreach (var method in methods)
+            {
+                var parameters = method.GetParameters();
+                if (ParameterIndex >= parameters.Length)
+                    continue;
+
+                var paramType = parameters[ParameterIndex].ParameterType;
+                if (paramType is { IsAbstract: false, IsInterface: false, FullName: not null })
+                    yield return paramType;
+            }
+        }
+    }
+}

--- a/DomainModeling/Builder/TypeConventionBuilder.cs
+++ b/DomainModeling/Builder/TypeConventionBuilder.cs
@@ -23,12 +23,22 @@ namespace DomainModeling.Builder;
 public sealed class TypeConventionBuilder
 {
     private readonly List<List<Func<Type, bool>>> _orBranches = [];
+    private readonly List<StructuralDomainEventRule> _structuralRules = [];
     private bool _mergeNextIntoCurrentBranch;
 
     /// <summary>
-    /// True when at least one convention rule has been configured.
+    /// True when at least one predicate convention rule has been configured.
     /// </summary>
     internal bool HasPredicates => _orBranches.Count > 0;
+
+    /// <summary>
+    /// Structural rules derive domain event types from handler types (method parameters).
+    /// </summary>
+    internal bool HasStructuralRules => _structuralRules.Count > 0;
+
+    internal IReadOnlyList<StructuralDomainEventRule> StructuralRules => _structuralRules;
+
+    internal void AddStructuralRule(StructuralDomainEventRule rule) => _structuralRules.Add(rule);
 
     /// <summary>
     /// AND the next rule with the current branch (the one formed by the immediately preceding rule).
@@ -144,6 +154,20 @@ public sealed class TypeConventionBuilder
         ArgumentNullException.ThrowIfNull(predicate);
         AddPredicate(predicate);
         return this;
+    }
+
+    /// <summary>
+    /// Begins a structural rule for domain events: choose handler types, then a method and parameter whose type is treated as a domain event.
+    /// Example: <c>Type(t => t.NameEndsWith("EventHandler")).HasMethod("Handle").Parameters().First().Type()</c>.
+    /// </summary>
+    public TypeStructuralSelector Type(Action<TypeConventionBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var nested = new TypeConventionBuilder();
+        configure(nested);
+        if (!nested.HasPredicates)
+            throw new InvalidOperationException("Type() requires at least one predicate in the nested convention (e.g. NameEndsWith(\"EventHandler\")).");
+        return new TypeStructuralSelector(this, nested);
     }
 
     /// <summary>

--- a/DomainModeling/Builder/TypeStructuralSelector.cs
+++ b/DomainModeling/Builder/TypeStructuralSelector.cs
@@ -1,0 +1,107 @@
+namespace DomainModeling.Builder;
+
+/// <summary>
+/// Begins a structural rule: match types (e.g. event handlers), then walk to a parameter type.
+/// </summary>
+public sealed class TypeStructuralSelector
+{
+    private readonly TypeConventionBuilder _owner;
+    private readonly TypeConventionBuilder _rootMatcher;
+
+    internal TypeStructuralSelector(TypeConventionBuilder owner, TypeConventionBuilder rootMatcher)
+    {
+        _owner = owner;
+        _rootMatcher = rootMatcher;
+    }
+
+    /// <summary>
+    /// Restrict to types that declare a public instance or static method with this name (first overload with enough parameters is used).
+    /// </summary>
+    public MethodParameterSelector HasMethod(string methodName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
+        return new MethodParameterSelector(_owner, _rootMatcher, methodName);
+    }
+}
+
+/// <summary>
+/// Selects which method parameter supplies the domain event type.
+/// </summary>
+public sealed class MethodParameterSelector
+{
+    private readonly TypeConventionBuilder _owner;
+    private readonly TypeConventionBuilder _rootMatcher;
+    private readonly string _methodName;
+
+    internal MethodParameterSelector(TypeConventionBuilder owner, TypeConventionBuilder rootMatcher, string methodName)
+    {
+        _owner = owner;
+        _rootMatcher = rootMatcher;
+        _methodName = methodName;
+    }
+
+    /// <summary>
+    /// Select from the method's formal parameters.
+    /// </summary>
+    public ParameterPositionSelector Parameters() => new(_owner, _rootMatcher, _methodName);
+}
+
+/// <summary>
+/// Chooses a parameter index, then completes the rule with <see cref="TypeExtractor.Type"/>.
+/// </summary>
+public sealed class ParameterPositionSelector
+{
+    private readonly TypeConventionBuilder _owner;
+    private readonly TypeConventionBuilder _rootMatcher;
+    private readonly string _methodName;
+
+    internal ParameterPositionSelector(TypeConventionBuilder owner, TypeConventionBuilder rootMatcher, string methodName)
+    {
+        _owner = owner;
+        _rootMatcher = rootMatcher;
+        _methodName = methodName;
+    }
+
+    /// <summary>Uses the first parameter (index 0).</summary>
+    public TypeExtractor First() => new(_owner, _rootMatcher, _methodName, 0);
+
+    /// <summary>Uses the parameter at the given zero-based index.</summary>
+    public TypeExtractor At(int index)
+    {
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index));
+        return new TypeExtractor(_owner, _rootMatcher, _methodName, index);
+    }
+}
+
+/// <summary>
+/// Completes a structural extraction by registering the parameter's type as a candidate domain event type.
+/// </summary>
+public sealed class TypeExtractor
+{
+    private readonly TypeConventionBuilder _owner;
+    private readonly TypeConventionBuilder _rootMatcher;
+    private readonly string _methodName;
+    private readonly int _parameterIndex;
+
+    internal TypeExtractor(
+        TypeConventionBuilder owner,
+        TypeConventionBuilder rootMatcher,
+        string methodName,
+        int parameterIndex)
+    {
+        _owner = owner;
+        _rootMatcher = rootMatcher;
+        _methodName = methodName;
+        _parameterIndex = parameterIndex;
+    }
+
+    /// <summary>
+    /// Registers this structural rule: discovered event types are taken from the selected parameter's type.
+    /// </summary>
+    public TypeConventionBuilder Type()
+    {
+        _owner.AddStructuralRule(new StructuralDomainEventRule(_rootMatcher, _methodName, _parameterIndex));
+        return _owner;
+    }
+}

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -62,6 +62,8 @@ internal sealed class AssemblyScanner
         var repositoryTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.RepositoryConvention.Matches(t)).ToList();
         var domainServiceTypes = allTypes.Where(t => !OwnedElsewhere(t) && _config.DomainServiceConvention.Matches(t)).ToList();
 
+        MergeStructuralDomainEvents(allTypes, OwnedElsewhere, domainEventTypes);
+
         // Build a set of all "known domain type" full names for reference detection
         var knownDomainTypes = new HashSet<string>(
             entityTypes.Concat(aggregateTypes).Concat(valueObjectTypes)
@@ -346,6 +348,34 @@ internal sealed class AssemblyScanner
             SubTypes = subTypeNodes,
             Relationships = relationships
         };
+    }
+
+    /// <summary>
+    /// Adds domain event types derived from <see cref="BoundedContextBuilder.DomainEventConvention"/> structural rules
+    /// (e.g. first parameter of <c>Handle</c> on types matching a nested convention).
+    /// </summary>
+    private void MergeStructuralDomainEvents(
+        List<Type> allTypes,
+        Func<Type, bool> ownedElsewhere,
+        List<Type> domainEventTypes)
+    {
+        var rules = _config.DomainEventConvention.StructuralRules;
+        if (rules.Count == 0)
+            return;
+
+        var existing = new HashSet<string>(domainEventTypes.Select(t => t.FullName!).Where(n => n is not null), StringComparer.Ordinal);
+        foreach (var rule in rules)
+        {
+            foreach (var eventType in rule.EnumerateEventTypes(allTypes))
+            {
+                if (ownedElsewhere(eventType))
+                    continue;
+                var fullName = eventType.FullName;
+                if (fullName is null || !existing.Add(fullName))
+                    continue;
+                domainEventTypes.Add(eventType);
+            }
+        }
     }
 
     // ─── Node builders ───────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **structural** option on `DomainEvents(...)` so domain event types can be collected from handler classes without requiring `InheritsFrom<YourBaseEvent>()`.

## API

On `TypeConventionBuilder` (used inside `DomainEvents`):

- `Type(t => { ... })` — nested convention selects **handler/root types** (same predicates as elsewhere: `NameEndsWith`, `Implements`, `And`, etc.).
- `.HasMethod("Handle")` — public instance/static methods declared on that type with the given name.
- `.Parameters().First()` or `.At(index)` — which parameter supplies the event type.
- `.Type()` — registers the rule and returns the builder for further OR branches.

Example:

```csharp
.DomainEvents(e => e
    .Type(t => t.NameEndsWith("EventHandler"))
    .HasMethod("Handle")
    .Parameters()
    .First()
    .Type())
```

Handlers that use `HandleAsync` (e.g. `IEventHandler<T>` in samples) need `HasMethod("HandleAsync")` instead.

## Scanner

After normal type-based matching, the scanner merges unique non-abstract, non-interface parameter types from structural rules (skipping types owned by another bounded context).

## Tests

- Structural rule discovers `CustomerCreatedEvent` from `PublishCustomerRegisteredWhenCreatedEventHandler`.
- Empty `Type(_ => { })` throws `InvalidOperationException`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5222e41-af5f-46fc-a994-8d431ad03257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5222e41-af5f-46fc-a994-8d431ad03257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

