### PR TITLE
C#-style generic names in graph and explorer (fix EntityDeletedEvent`1 display)

### DIFF
--- a/DomainModeling.AspNetCore/wwwroot/js/helpers.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/helpers.js
@@ -4,8 +4,88 @@
 
 export function shortName(fullName) {
   if (!fullName) return '';
-  const parts = fullName.split('.');
+  const s = String(fullName);
+  if (s.indexOf('`') >= 0 || s.indexOf('[[') >= 0) return displayShortName(s);
+  const parts = s.split('.');
   return parts[parts.length - 1];
+}
+
+/**
+ * Human-readable short name for a CLR type string (reflection FullName / relationship keys).
+ * e.g. Namespace.EntityDeletedEvent`1[[Ns.User, Asm,...]] → EntityDeletedEvent<User>
+ */
+export function displayShortName(fullName) {
+  if (!fullName) return '';
+  const s = String(fullName);
+  const lastDot = s.lastIndexOf('.');
+  const segment = lastDot >= 0 ? s.slice(lastDot + 1) : s;
+  return formatClrTypeSegment(segment);
+}
+
+/**
+ * Formats one namespace-less CLR type segment (may include `arity and [[assembly-qualified args]]`).
+ */
+export function formatClrTypeSegment(segment) {
+  if (!segment) return '';
+  const tick = segment.indexOf('`');
+  if (tick < 0) return segment;
+
+  const base = segment.slice(0, tick);
+  let i = tick + 1;
+  while (i < segment.length && segment[i] >= '0' && segment[i] <= '9') i++;
+  if (i >= segment.length || segment.slice(i, i + 2) !== '[[') return base;
+
+  const args = [];
+  let pos = i;
+  while (pos < segment.length && segment.slice(pos, pos + 2) === '[[') {
+    const innerEnd = matchDoubleBracketContentEnd(segment, pos + 2);
+    if (innerEnd < 0) break;
+    const inner = segment.slice(pos + 2, innerEnd);
+    args.push(parseAssemblyQualifiedTypeName(inner));
+    pos = innerEnd + 2;
+    while (pos < segment.length && (segment[pos] === ',' || segment[pos] === ' ')) pos++;
+  }
+  return args.length ? `${base}<${args.join(', ')}>` : base;
+}
+
+/**
+ * Content starts after opening `[[`. Returns index of first `]` of the matching closing `]]`.
+ */
+function matchDoubleBracketContentEnd(s, contentStart) {
+  let depth = 1;
+  let i = contentStart;
+  while (i < s.length && depth > 0) {
+    if (i + 1 < s.length && s[i] === '[' && s[i + 1] === '[') {
+      depth++;
+      i += 2;
+    } else if (i + 1 < s.length && s[i] === ']' && s[i + 1] === ']') {
+      depth--;
+      i += 2;
+    } else i++;
+  }
+  return depth === 0 ? i - 2 : -1;
+}
+
+function parseAssemblyQualifiedTypeName(inner) {
+  const typePart = stripAssemblyQualifier(inner.trim());
+  if (!typePart) return '';
+  if (typePart.indexOf('`') >= 0) return formatClrTypeSegment(typePart);
+  const parts = typePart.split('.');
+  return parts[parts.length - 1] || typePart;
+}
+
+/** Removes `, Assembly` / `, Version=` suffix from a CLR assembly-qualified type string. */
+function stripAssemblyQualifier(s) {
+  if (!s) return '';
+  const v = s.indexOf(', Version=');
+  if (v > 0) return s.slice(0, v).trim();
+  const c = s.indexOf(', Culture=');
+  if (c > 0) return s.slice(0, c).trim();
+  const pk = s.indexOf(', PublicKeyToken=');
+  if (pk > 0) return s.slice(0, pk).trim();
+  const simple = s.indexOf(', ');
+  if (simple > 0 && s.indexOf('`') < 0) return s.slice(0, simple).trim();
+  return s.trim();
 }
 
 /**
@@ -58,21 +138,30 @@ export function truncateDiagramText(str, maxChars = DIAGRAM_NODE_TEXT_MAX_CHARS)
 
 /** Display string for a property row on the diagram canvas (frontend only). */
 export function formatDiagramPropertyLine(propName, typeName) {
-  const raw = `${propName || ''}: ${stripGenericTypeArgs(typeName || '')}`;
+  const t = formatDiagramTypeName(typeName || '');
+  const raw = `${propName || ''}: ${t}`;
   return truncateDiagramText(raw);
 }
 
 /** Display string for a method signature row on the diagram canvas (frontend only). */
 export function formatDiagramMethodLine(method) {
   if (!method) return '';
-  const params = (method.parameters || []).map(p => stripGenericTypeArgs(p.typeName || '')).join(', ');
-  const raw = `${method.name || ''}(${params})`;
+  const ret = formatDiagramTypeName(method.returnTypeName || '');
+  const params = (method.parameters || []).map(p => formatDiagramTypeName(p.typeName || '')).join(', ');
+  const raw = `${ret} ${method.name || ''}(${params})`;
   return truncateDiagramText(raw);
+}
+
+function formatDiagramTypeName(typeName) {
+  if (!typeName) return '';
+  if (typeName.indexOf('`') >= 0 || typeName.indexOf('[[') >= 0) return displayShortName(typeName);
+  return stripGenericTypeArgs(typeName);
 }
 
 /** Event row from domain `emittedEvents` full names (shortName + ellipsis). */
 export function formatDiagramEmittedEventLine(eventFullName) {
-  return formatDiagramEventBadgeLine(shortName(eventFullName || ''));
+  const label = formatDiagramTypeName(eventFullName || '') || shortName(eventFullName || '');
+  return formatDiagramEventBadgeLine(label);
 }
 
 /** Event row when the label is already a display name (feature editor derived events). */

--- a/DomainModeling/Discovery/AssemblyScanner.cs
+++ b/DomainModeling/Discovery/AssemblyScanner.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using DomainModeling;
 using DomainModeling.Builder;
 using DomainModeling.Graph;
 using MethodInfo = DomainModeling.Graph.MethodInfo;
@@ -385,7 +386,7 @@ internal sealed class AssemblyScanner
         var emissions = DetectEventEmissions(type, eventTypes, _documentationIndexer);
         return new EntityNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -411,7 +412,7 @@ internal sealed class AssemblyScanner
 
         return new AggregateNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -427,7 +428,7 @@ internal sealed class AssemblyScanner
     {
         return new ValueObjectNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -439,7 +440,7 @@ internal sealed class AssemblyScanner
     {
         return new DomainEventNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -478,7 +479,7 @@ internal sealed class AssemblyScanner
 
         return new HandlerNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -498,7 +499,7 @@ internal sealed class AssemblyScanner
 
         return new RepositoryNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -510,7 +511,7 @@ internal sealed class AssemblyScanner
     {
         return new DomainServiceNode
         {
-            Name = type.Name,
+            Name = TypeDisplayNames.ShortName(type),
             FullName = type.FullName!,
             Layer = layer,
             Description = _documentationIndexer?.TryGetDomainSummary(type)
@@ -639,7 +640,7 @@ internal sealed class AssemblyScanner
 
     private CommandHandlerTargetNode BuildCommandHandlerTargetNode(Type type, HashSet<string> knownDomainTypes) => new()
     {
-        Name = type.Name,
+        Name = TypeDisplayNames.ShortName(type),
         FullName = type.FullName!,
         Layer = _config.GetLayer(type),
         Description = _documentationIndexer?.TryGetDomainSummary(type),
@@ -729,43 +730,16 @@ internal sealed class AssemblyScanner
             .Select(m => new MethodInfo
             {
                 Name = m.Name,
-                ReturnTypeName = FormatTypeName(m.ReturnType),
+                ReturnTypeName = TypeDisplayNames.FormatTypeReference(m.ReturnType),
                 Parameters = m.GetParameters()
                     .Select(p => new MethodParameterInfo
                     {
                         Name = p.Name ?? "arg",
-                        TypeName = FormatTypeName(p.ParameterType),
+                        TypeName = TypeDisplayNames.FormatTypeReference(p.ParameterType),
                     })
                     .ToList()
             })
             .ToList();
-    }
-
-    private static string FormatTypeName(Type type)
-    {
-        if (type == typeof(void)) return "void";
-        if (type == typeof(string)) return "string";
-        if (type == typeof(int)) return "int";
-        if (type == typeof(long)) return "long";
-        if (type == typeof(bool)) return "bool";
-        if (type == typeof(double)) return "double";
-        if (type == typeof(decimal)) return "decimal";
-        if (type == typeof(float)) return "float";
-        if (type == typeof(Guid)) return "Guid";
-
-        if (type.IsGenericType)
-        {
-            var baseName = StripGenericArity(type.Name);
-            var args = string.Join(", ", type.GetGenericArguments().Select(FormatTypeName));
-            return $"{baseName}<{args}>";
-        }
-
-        if (type.IsArray)
-        {
-            return FormatTypeName(type.GetElementType()!) + "[]";
-        }
-
-        return type.Name;
     }
 
     private static (string TypeName, bool IsCollection, Type? ElementType) AnalyzePropertyType(Type type)
@@ -774,7 +748,7 @@ internal sealed class AssemblyScanner
         if (type.IsArray)
         {
             var elem = type.GetElementType()!;
-            return ($"{elem.Name}[]", true, elem);
+            return ($"{TypeDisplayNames.FormatTypeReference(elem)}[]", true, elem);
         }
 
         // Check for generic collections (IEnumerable<T>, ICollection<T>, List<T>, etc.)
@@ -785,15 +759,16 @@ internal sealed class AssemblyScanner
 
             if (args.Length == 1 && IsCollectionType(genericDef))
             {
-                return ($"ICollection<{args[0].Name}>", true, args[0]);
+                return ($"ICollection<{TypeDisplayNames.FormatTypeReference(args[0])}>", true, args[0]);
             }
 
             // Generic but not a collection (e.g. Nullable<T>)
-            var argNames = string.Join(", ", args.Select(a => a.Name));
-            return ($"{StripGenericArity(type.Name)}<{argNames}>", false, null);
+            var argNames = string.Join(", ", args.Select(TypeDisplayNames.FormatTypeReference));
+            var defName = StripGenericArity(type.Name);
+            return ($"{defName}<{argNames}>", false, null);
         }
 
-        return (type.Name, false, null);
+        return (TypeDisplayNames.FormatTypeReference(type), false, null);
     }
 
     private static bool IsCollectionType(Type genericDef)
@@ -1480,7 +1455,7 @@ internal sealed class AssemblyScanner
             var properties = GetProperties(type, knownDomainTypes);
             subTypeNodes.Add(new SubTypeNode
             {
-                Name = type.Name,
+                Name = TypeDisplayNames.ShortName(type),
                 FullName = fullName,
                 Description = _documentationIndexer?.TryGetDomainSummary(type),
                 Properties = properties

--- a/DomainModeling/TypeDisplayNames.cs
+++ b/DomainModeling/TypeDisplayNames.cs
@@ -1,0 +1,91 @@
+namespace DomainModeling;
+
+/// <summary>
+/// C#-style display names for <see cref="System.Type"/> (nested types, generics, arity markers).
+/// Used for graph node <c>Name</c> and type references in property/method metadata.
+/// </summary>
+internal static class TypeDisplayNames
+{
+    /// <summary>
+    /// Short type name for UI: nested types as <c>Outer.Inner</c>, closed generics as <c>Event&lt;T&gt;</c> (no <c>`1</c>).
+    /// </summary>
+    public static string ShortName(Type type)
+    {
+        if (type.IsGenericParameter || type.IsGenericTypeParameter)
+            return type.Name;
+
+        if (type.IsArray)
+            return ShortName(type.GetElementType()!) + "[]";
+
+        if (type.IsGenericType)
+        {
+            // Open generic definition: show "EntityDeletedEvent", not "EntityDeletedEvent`1" / not "EntityDeletedEvent<TEntity>"
+            if (type.IsGenericTypeDefinition)
+                return StripArity(type.Name);
+
+            var defName = StripArity(type.IsNested ? type.Name : type.Name);
+            var args = string.Join(", ", type.GetGenericArguments().Select(ShortName));
+            if (type.IsNested)
+                return $"{ShortName(type.DeclaringType!)}.{defName}<{args}>";
+            return $"{defName}<{args}>";
+        }
+
+        if (type.IsNested)
+            return $"{ShortName(type.DeclaringType!)}.{type.Name}";
+
+        return type.Name;
+    }
+
+    /// <summary>
+    /// Type as it would appear in C# source (keywords for primitives, nested + generics).
+    /// </summary>
+    public static string FormatTypeReference(Type type)
+    {
+        if (type.IsGenericParameter || type.IsGenericTypeParameter)
+            return type.Name;
+
+        if (type == typeof(void)) return "void";
+        if (type == typeof(string)) return "string";
+        if (type == typeof(int)) return "int";
+        if (type == typeof(long)) return "long";
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(decimal)) return "decimal";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(byte)) return "byte";
+        if (type == typeof(short)) return "short";
+        if (type == typeof(uint)) return "uint";
+        if (type == typeof(ulong)) return "ulong";
+        if (type == typeof(char)) return "char";
+        if (type == typeof(object)) return "object";
+        if (type == typeof(nint)) return "nint";
+        if (type == typeof(nuint)) return "nuint";
+        if (type == typeof(Guid)) return "Guid";
+
+        if (type.IsGenericType)
+        {
+            if (type.IsGenericTypeDefinition)
+                return $"{StripArity(type.Name)}<>";
+
+            var defName = StripArity(type.IsNested ? type.Name : type.Name);
+            var args = string.Join(", ", type.GetGenericArguments().Select(FormatTypeReference));
+            if (type.IsNested)
+                return $"{FormatTypeReference(type.DeclaringType!)}.{defName}<{args}>";
+            return $"{defName}<{args}>";
+        }
+
+        if (type.IsArray)
+            return $"{FormatTypeReference(type.GetElementType()!)}[]";
+
+        if (type.IsNested)
+            return $"{FormatTypeReference(type.DeclaringType!)}.{type.Name}";
+
+        return type.Name;
+    }
+
+    private static string StripArity(string name)
+    {
+        var idx = name.IndexOf('`');
+        return idx >= 0 ? name[..idx] : name;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves how **generic types** and **method signatures** appear in the embedded explorer and diagram:

- **Graph JSON**: `Name` for types now uses C#-style short names (e.g. `EntityDeletedEvent<Customer>` instead of `EntityDeletedEvent`1`). Open generic **definitions** stay unparameterized (`EntityDeletedEvent`) so existing relationship keys and tests remain valid.
- **Properties / aggregate methods**: `TypeName` strings use the same formatter (keywords, nested types, generics).
- **Frontend**: `shortName()` and diagram helpers parse CLR `fullName` strings that still contain backticks and `[[assembly-qualified]]` segments, so relationship rows and labels show `EntityDeletedEvent<User>`-style text. Method lines on the diagram use `returnType name(params)`.

## Implementation

- New `TypeDisplayNames` helper in the core library; `AssemblyScanner` uses it for node names and `GetProperties` / `GetMethods` metadata.
- `helpers.js`: `displayShortName`, `formatClrTypeSegment`, extended `shortName`, and updated `formatDiagramMethodLine` / emitted event lines.

## Tests

All 65 xUnit tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5222e41-af5f-46fc-a994-8d431ad03257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5222e41-af5f-46fc-a994-8d431ad03257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

