### PR TITLE
Scaffold ubiquitous language Markdown export (#63)

### DIFF
--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -67,6 +67,24 @@ public sealed class DomainModelOptions
     /// </summary>
     public DomainModelTestingOptions Testing { get; } = new();
 
+    /// <summary>
+    /// Phrases and languages for ubiquitous language JSON, Markdown export, and the Language tab.
+    /// Replace with <see cref="UseUbiquitousLanguage"/> to add translations or change copy.
+    /// </summary>
+    public UbiquitousLanguageDefinition UbiquitousLanguage { get; set; } = UbiquitousLanguageDefinition.CreateDefault();
+
+    /// <summary>
+    /// Replaces <see cref="UbiquitousLanguage"/> using a fluent builder (add languages, change defaults).
+    /// </summary>
+    public DomainModelOptions UseUbiquitousLanguage(Action<UbiquitousLanguageDefinitionBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var builder = UbiquitousLanguageDefinitionBuilder.Create();
+        configure(builder);
+        UbiquitousLanguage = builder.Build();
+        return this;
+    }
+
     internal List<ExportRegistration> Exports { get; } = [];
 
     internal List<FeatureExportRegistration> FeatureExports { get; } = [];
@@ -248,10 +266,14 @@ public static class DomainModelEndpointExtensions
             }
         }
 
-        // GET /domain-model/ubiquitous-language — structured ubiquitous language (matches Markdown export rules)
-        endpoints.MapGet($"{routePrefix}/ubiquitous-language", () =>
+        // GET /domain-model/ubiquitous-language?lang=nl — structured ubiquitous language (matches Markdown export rules)
+        endpoints.MapGet($"{routePrefix}/ubiquitous-language", (HttpRequest http) =>
         {
-            var doc = UbiquitousLanguageDocumentBuilder.Build(ResolveGraphForDerivedViews());
+            var lang = http.Query["lang"].FirstOrDefault();
+            var doc = UbiquitousLanguageDocumentBuilder.Build(
+                ResolveGraphForDerivedViews(),
+                options.UbiquitousLanguage,
+                lang);
             return Results.Json(doc, new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -170,6 +170,7 @@ public static class DomainModelEndpointExtensions
     /// <para>
     /// <c>GET {routePrefix}</c> — serves the interactive HTML explorer.<br/>
     /// <c>GET {routePrefix}/json</c> — returns the raw domain graph JSON.<br/>
+    /// <c>GET {routePrefix}/ubiquitous-language</c> — returns structured ubiquitous language JSON for the explorer Language tab.<br/>
     /// <c>GET {routePrefix}/assets/**</c> — serves CSS and JS modules.
     /// </para>
     /// When <see cref="DomainModelOptions.EnableDeveloperView"/> is <c>true</c>,
@@ -234,6 +235,33 @@ public static class DomainModelEndpointExtensions
         endpoints.MapGet($"{routePrefix}/json", () => Results.Content(json, "application/json"))
             .ExcludeFromDescription()
             .WithName("DomainModelJson");
+
+        DomainGraph ResolveGraphForDerivedViews()
+        {
+            try
+            {
+                return DomainGraph.FromJson(json);
+            }
+            catch
+            {
+                return graph;
+            }
+        }
+
+        // GET /domain-model/ubiquitous-language — structured ubiquitous language (matches Markdown export rules)
+        endpoints.MapGet($"{routePrefix}/ubiquitous-language", () =>
+        {
+            var doc = UbiquitousLanguageDocumentBuilder.Build(ResolveGraphForDerivedViews());
+            return Results.Json(doc, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+            });
+        })
+        .ExcludeFromDescription()
+        .WithName("DomainModelUbiquitousLanguage");
 
         // GET /domain-model/metadata — return all custom type metadata
         endpoints.MapGet($"{routePrefix}/metadata", () =>

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -188,7 +188,8 @@ public static class DomainModelEndpointExtensions
     /// <para>
     /// <c>GET {routePrefix}</c> — serves the interactive HTML explorer.<br/>
     /// <c>GET {routePrefix}/json</c> — returns the raw domain graph JSON.<br/>
-    /// <c>GET {routePrefix}/ubiquitous-language</c> — returns structured ubiquitous language JSON for the explorer Language tab.<br/>
+    /// <c>GET {routePrefix}/ubiquitous-language</c> — structured ubiquitous language JSON (Language tab).<br/>
+    /// <c>GET {routePrefix}/ubiquitous-language.md</c> — same content as Markdown (<c>UbiquitousLanguageMarkdownExport</c>), optional <c>?lang=</c>.<br/>
     /// <c>GET {routePrefix}/assets/**</c> — serves CSS and JS modules.
     /// </para>
     /// When <see cref="DomainModelOptions.EnableDeveloperView"/> is <c>true</c>,
@@ -266,7 +267,7 @@ public static class DomainModelEndpointExtensions
             }
         }
 
-        // GET /domain-model/ubiquitous-language?lang=nl — structured ubiquitous language (matches Markdown export rules)
+        // GET /domain-model/ubiquitous-language?lang=nl — structured ubiquitous language (same graph + definition as Markdown)
         endpoints.MapGet($"{routePrefix}/ubiquitous-language", (HttpRequest http) =>
         {
             var lang = http.Query["lang"].FirstOrDefault();
@@ -284,6 +285,26 @@ public static class DomainModelEndpointExtensions
         })
         .ExcludeFromDescription()
         .WithName("DomainModelUbiquitousLanguage");
+
+        // GET /domain-model/ubiquitous-language.md?lang=nl — Markdown download (same pipeline as UbiquitousLanguageMarkdownExport + JSON page)
+        endpoints.MapGet($"{routePrefix}/ubiquitous-language.md", (HttpRequest http) =>
+        {
+            var lang = http.Query["lang"].FirstOrDefault();
+            var md = UbiquitousLanguageMarkdownExport.Build(
+                ResolveGraphForDerivedViews(),
+                options.UbiquitousLanguage,
+                lang);
+            var safeLang = string.IsNullOrWhiteSpace(lang) ? null : SanitizeFileName(lang.Trim());
+            var fileName = safeLang is { Length: > 0 }
+                ? $"ubiquitous-language-{safeLang}.md"
+                : "ubiquitous-language.md";
+            return Results.File(
+                Encoding.UTF8.GetBytes(md),
+                "text/markdown; charset=utf-8",
+                fileName);
+        })
+        .ExcludeFromDescription()
+        .WithName("DomainModelUbiquitousLanguageMarkdown");
 
         // GET /domain-model/metadata — return all custom type metadata
         endpoints.MapGet($"{routePrefix}/metadata", () =>
@@ -311,7 +332,7 @@ public static class DomainModelEndpointExtensions
                 if (export is null)
                     return Results.NotFound();
 
-                var content = export.Builder(graph);
+                var content = export.Builder(ResolveGraphForDerivedViews());
                 var fileName = $"{export.Name.ToLowerInvariant().Replace(' ', '-')}.{export.FileExtension}";
                 return Results.File(
                     System.Text.Encoding.UTF8.GetBytes(content),

--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -188,8 +188,8 @@ public static class DomainModelEndpointExtensions
     /// <para>
     /// <c>GET {routePrefix}</c> — serves the interactive HTML explorer.<br/>
     /// <c>GET {routePrefix}/json</c> — returns the raw domain graph JSON.<br/>
-    /// <c>GET {routePrefix}/ubiquitous-language</c> — structured ubiquitous language JSON (Language tab).<br/>
-    /// <c>GET {routePrefix}/ubiquitous-language.md</c> — same content as Markdown (<c>UbiquitousLanguageMarkdownExport</c>), optional <c>?lang=</c>.<br/>
+    /// <c>GET {routePrefix}/ubiquitous-language</c> — structured ubiquitous language JSON (Language tab); optional <c>?lang=</c>, <c>?context=Name</c> (repeatable or comma-separated) to limit bounded contexts.<br/>
+    /// <c>GET {routePrefix}/ubiquitous-language.md</c> — same Markdown pipeline; same query options.<br/>
     /// <c>GET {routePrefix}/assets/**</c> — serves CSS and JS modules.
     /// </para>
     /// When <see cref="DomainModelOptions.EnableDeveloperView"/> is <c>true</c>,
@@ -267,14 +267,31 @@ public static class DomainModelEndpointExtensions
             }
         }
 
-        // GET /domain-model/ubiquitous-language?lang=nl — structured ubiquitous language (same graph + definition as Markdown)
+        static List<string>? ParseUbiquitousLanguageContextQuery(IQueryCollection query)
+        {
+            if (!query.TryGetValue("context", out var values) || values.Count == 0)
+                return null;
+            var list = new List<string>();
+            foreach (var v in values)
+            {
+                if (string.IsNullOrWhiteSpace(v))
+                    continue;
+                foreach (var part in v.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                    list.Add(part);
+            }
+            return list.Count > 0 ? list : null;
+        }
+
+        // GET /domain-model/ubiquitous-language?lang=nl&context=Catalog&context=Shipping — structured ubiquitous language (same graph + definition as Markdown)
         endpoints.MapGet($"{routePrefix}/ubiquitous-language", (HttpRequest http) =>
         {
             var lang = http.Query["lang"].FirstOrDefault();
+            var contexts = ParseUbiquitousLanguageContextQuery(http.Query);
             var doc = UbiquitousLanguageDocumentBuilder.Build(
                 ResolveGraphForDerivedViews(),
                 options.UbiquitousLanguage,
-                lang);
+                lang,
+                contexts);
             return Results.Json(doc, new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -286,18 +303,27 @@ public static class DomainModelEndpointExtensions
         .ExcludeFromDescription()
         .WithName("DomainModelUbiquitousLanguage");
 
-        // GET /domain-model/ubiquitous-language.md?lang=nl — Markdown download (same pipeline as UbiquitousLanguageMarkdownExport + JSON page)
+        // GET /domain-model/ubiquitous-language.md?lang=nl&context=Catalog — Markdown download (same pipeline as JSON page)
         endpoints.MapGet($"{routePrefix}/ubiquitous-language.md", (HttpRequest http) =>
         {
             var lang = http.Query["lang"].FirstOrDefault();
+            var contexts = ParseUbiquitousLanguageContextQuery(http.Query);
             var md = UbiquitousLanguageMarkdownExport.Build(
                 ResolveGraphForDerivedViews(),
                 options.UbiquitousLanguage,
-                lang);
+                lang,
+                contexts);
             var safeLang = string.IsNullOrWhiteSpace(lang) ? null : SanitizeFileName(lang.Trim());
-            var fileName = safeLang is { Length: > 0 }
-                ? $"ubiquitous-language-{safeLang}.md"
-                : "ubiquitous-language.md";
+            var safeCtx = contexts is { Count: 1 } && SanitizeFileName(contexts[0]) is { } sc && sc.Length > 0
+                ? sc.ToLowerInvariant().Replace(' ', '-')
+                : null;
+            var fileName = (safeLang, safeCtx) switch
+            {
+                ({ } l, { } c) => $"ubiquitous-language-{l}-{c}.md",
+                ({ } l, null) => $"ubiquitous-language-{l}.md",
+                (null, { } c) => $"ubiquitous-language-{c}.md",
+                _ => "ubiquitous-language.md",
+            };
             return Results.File(
                 Encoding.UTF8.GetBytes(md),
                 "text/markdown; charset=utf-8",

--- a/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
@@ -1,19 +1,47 @@
 /* Ubiquitous language reader — warm, readable doc layout */
 
-.ul-lang-toolbar {
+.ul-top-toolbar {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   flex-wrap: wrap;
-  gap: 10px 14px;
-  padding: 8px 16px 0;
+  gap: 12px 16px;
+  padding: 10px 16px 12px;
   max-width: 920px;
   margin: 0 auto;
+  border-bottom: 1px solid var(--ul-border, #2d3340);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, transparent 100%);
 }
 
-.ul-lang-toolbar-spacer {
+.ul-bc-filter-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ul-bc-filter-label {
+  font-size: 0.78rem;
+  color: var(--ul-muted, #8b92a8);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.ul-bc-select {
+  min-width: 10rem;
+  max-width: min(22rem, 100%);
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--ul-border, #2d3340);
+  background: var(--ul-card, #1a1d24);
+  color: var(--text, #e4e6ec);
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ul-toolbar-spacer {
   flex: 1;
-  min-width: 8px;
+  min-width: 4px;
 }
 
 .ul-lang-toolbar-inner {

--- a/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
@@ -4,10 +4,22 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 10px 14px;
   padding: 8px 16px 0;
   max-width: 920px;
   margin: 0 auto;
+}
+
+.ul-lang-toolbar-spacer {
+  flex: 1;
+  min-width: 8px;
+}
+
+.ul-lang-toolbar-inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .ul-lang-label {
@@ -26,6 +38,27 @@
   color: var(--text, #e4e6ec);
   font-size: 0.86rem;
   cursor: pointer;
+}
+
+.ul-download-btn {
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(196, 165, 116, 0.45);
+  background: var(--ul-accent-soft, rgba(196, 165, 116, 0.12));
+  color: #e8dcc8;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.ul-download-btn:hover:not(:disabled) {
+  background: rgba(196, 165, 116, 0.22);
+}
+
+.ul-download-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .ul-lang-badge {

--- a/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
@@ -1,5 +1,42 @@
 /* Ubiquitous language reader — warm, readable doc layout */
 
+.ul-lang-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 8px 16px 0;
+  max-width: 920px;
+  margin: 0 auto;
+}
+
+.ul-lang-label {
+  font-size: 0.78rem;
+  color: var(--ul-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.ul-lang-select {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--ul-border);
+  background: var(--ul-card);
+  color: var(--text, #e4e6ec);
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ul-lang-badge {
+  margin: 0 0 8px !important;
+  font-size: 0.75rem !important;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ul-accent) !important;
+}
+
 .ubiquitous-lang-page {
   --ul-accent: #c4a574;
   --ul-accent-soft: rgba(196, 165, 116, 0.15);

--- a/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/ubiquitous-language.css
@@ -1,0 +1,319 @@
+/* Ubiquitous language reader — warm, readable doc layout */
+
+.ubiquitous-lang-page {
+  --ul-accent: #c4a574;
+  --ul-accent-soft: rgba(196, 165, 116, 0.15);
+  --ul-card: var(--bg-card, #1a1d24);
+  --ul-border: var(--border, #2d3340);
+  --ul-muted: var(--text-muted, #8b92a8);
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 8px 16px 48px;
+}
+
+.ubiquitous-lang-page--loading {
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ul-loading,
+.ul-error {
+  color: var(--ul-muted);
+  font-size: 0.95rem;
+}
+
+.ul-error {
+  color: #f87171;
+}
+
+.ul-hero {
+  text-align: center;
+  padding: 28px 20px 32px;
+  margin-bottom: 8px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, var(--ul-accent-soft) 0%, transparent 55%),
+    var(--ul-card);
+  border: 1px solid var(--ul-border);
+}
+
+.ul-hero h1 {
+  margin: 0 0 10px;
+  font-size: 1.65rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  background: linear-gradient(110deg, #f0e6d8 0%, var(--ul-accent) 45%, #e8dcc8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.ul-hero p {
+  margin: 0 auto;
+  max-width: 52ch;
+  color: var(--ul-muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.ul-bc {
+  margin-top: 28px;
+  border-radius: 14px;
+  border: 1px solid var(--ul-border);
+  background: var(--ul-card);
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+
+.ul-bc-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  background: linear-gradient(90deg, rgba(196, 165, 116, 0.12) 0%, transparent 100%);
+  border-bottom: 1px solid var(--ul-border);
+}
+
+.ul-bc-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  background: var(--ul-accent-soft);
+  border: 1px solid rgba(196, 165, 116, 0.35);
+}
+
+.ul-bc-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.ul-bc-body {
+  padding: 20px 20px 8px;
+}
+
+.ul-section {
+  margin-bottom: 28px;
+}
+
+.ul-section > h3 {
+  margin: 0 0 14px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ul-muted);
+}
+
+.ul-empty {
+  color: var(--ul-muted);
+  font-style: italic;
+  font-size: 0.88rem;
+  padding: 8px 0 16px;
+}
+
+/* Aggregate root card */
+.ul-root {
+  margin-bottom: 20px;
+  border-radius: 12px;
+  border: 1px solid var(--ul-border);
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.ul-root-header {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ul-border);
+  background: linear-gradient(180deg, rgba(212, 160, 255, 0.08) 0%, transparent 100%);
+}
+
+.ul-root-title {
+  margin: 0;
+  font-size: 1.12rem;
+  font-weight: 600;
+}
+
+.ul-root-meta {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  color: var(--ul-muted);
+}
+
+.ul-root-meta code {
+  font-size: 0.76rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--ul-border);
+}
+
+.ul-desc {
+  margin: 0;
+  padding: 14px 18px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--text, #e4e6ec);
+  border-bottom: 1px solid var(--ul-border);
+}
+
+.ul-relations {
+  padding: 12px 18px 16px;
+}
+
+.ul-relations h4 {
+  margin: 0 0 10px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ul-muted);
+}
+
+.ul-rel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ul-rel-list li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  font-size: 0.88rem;
+}
+
+.ul-rel-list li:last-child {
+  border-bottom: none;
+}
+
+.ul-rel-phrase {
+  font-weight: 600;
+  color: #7ab8ff;
+  min-width: 5.5rem;
+}
+
+.ul-rel-target {
+  font-weight: 500;
+  color: #e8ecf4;
+}
+
+.ul-rel-via {
+  font-size: 0.8rem;
+  color: var(--ul-muted);
+}
+
+/* Nested concepts */
+.ul-nested {
+  margin: 0;
+  padding: 0 12px 12px 18px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.06);
+}
+
+.ul-nested-block {
+  margin-top: 12px;
+  padding-left: 14px;
+  border-left: 2px solid rgba(196, 165, 116, 0.35);
+}
+
+.ul-nested-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.ul-nested-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.ul-kind-pill {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(122, 184, 255, 0.12);
+  color: #9ec8ff;
+  border: 1px solid rgba(122, 184, 255, 0.25);
+}
+
+.ul-kind-pill.vo {
+  background: rgba(78, 232, 173, 0.1);
+  color: #7ee8c0;
+  border-color: rgba(78, 232, 173, 0.25);
+}
+
+.ul-kind-pill.st {
+  background: rgba(160, 180, 200, 0.12);
+  color: #b8c4d4;
+  border-color: rgba(160, 180, 200, 0.22);
+}
+
+.ul-kind-pill.agg {
+  background: rgba(212, 160, 255, 0.12);
+  color: #d8b8f0;
+  border-color: rgba(212, 160, 255, 0.28);
+}
+
+.ul-nested .ul-desc {
+  padding: 0 0 8px;
+  border: none;
+  font-size: 0.86rem;
+}
+
+.ul-nested .ul-relations {
+  padding: 0 0 4px;
+}
+
+.ul-nested .ul-relations h4 {
+  font-size: 0.68rem;
+}
+
+/* Domain events grid */
+.ul-events {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .ul-events {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.ul-event-card {
+  border-radius: 10px;
+  border: 1px solid var(--ul-border);
+  padding: 14px 16px;
+  background: linear-gradient(160deg, rgba(253, 208, 78, 0.06) 0%, transparent 50%);
+}
+
+.ul-event-card h4 {
+  margin: 0 0 8px;
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
+.ul-event-card .ul-desc {
+  padding: 0;
+  border: none;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.ul-event-card .ul-root-meta {
+  margin-top: 0;
+}

--- a/DomainModeling.AspNetCore/wwwroot/domain-model.html
+++ b/DomainModeling.AspNetCore/wwwroot/domain-model.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="{{ASSETS_URL}}/css/feature-editor.css" />
 <link rel="stylesheet" href="{{ASSETS_URL}}/css/testing.css" />
 <link rel="stylesheet" href="{{ASSETS_URL}}/css/trace.css" />
+<link rel="stylesheet" href="{{ASSETS_URL}}/css/ubiquitous-language.css" />
 {{TRACE_SIGNALR_SCRIPT}}
 </head>
 <body>

--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -535,7 +535,8 @@ export function setDiagramTraceHighlights(fullNames) {
  */
 export function renderDiagramView(opts = {}) {
   const traceLayout = opts.traceLayout === true;
-  let html = renderTabBar(traceLayout ? 'trace' : 'diagram');
+  const activeTab = opts.activeTab || (traceLayout ? 'trace' : 'diagram');
+  let html = renderTabBar(activeTab);
 
   const wrapClass = traceLayout ? 'diagram-wrap trace-diagram-inner' : 'diagram-wrap';
   html += `<div class="${wrapClass}" id="diagramWrap">`;

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -3,6 +3,7 @@
  */
 import { esc, escAttr, shortName, ALL_SECTIONS, SECTION_META, SECTION_TO_DIAGRAM_KIND } from './helpers.js';
 import { renderDetailView } from './views.js';
+import { renderUbiquitousLanguageView, mountUbiquitousLanguage } from './ubiquitous-language.js';
 import {
   renderDiagramView, initDiagram, diagramZoom, diagramFit, diagramResetLayout, diagramToggleKind, diagramShowAll,
   diagramDownloadSvg, diagramToggleAliases, diagramToggleLayers, diagramToggleEdgeKind, diagramToggleEdgeFilter,
@@ -295,6 +296,10 @@ function renderSidebar() {
     <div class="nav-item${currentView === 'diagram' ? ' active' : ''}" onclick="window.__nav.switchTab('diagram')">
       <span class="nav-dot" style="background:var(--clr-relationship)"></span>
       Diagram
+    </div>
+    <div class="nav-item${currentView === 'ubiquitous-language' ? ' active' : ''}" onclick="window.__nav.switchTab('ubiquitous-language')">
+      <span class="nav-dot" style="background:#c4a574"></span>
+      Language
     </div>`;
 
   if (FEATURE_EDITOR_MODE) {
@@ -421,6 +426,12 @@ function renderMain() {
     main.innerHTML = traceModule.renderTraceView();
     const selectedCtxs = (data.boundedContexts || []).filter(c => selectedContextNames.has(c.name));
     traceModule.mountTrace(currentCtx, selectedCtxs);
+    return;
+  }
+
+  if (currentView === 'ubiquitous-language') {
+    main.innerHTML = renderUbiquitousLanguageView();
+    void mountUbiquitousLanguage(BASE_URL, selectedContextNames);
     return;
   }
 

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -431,7 +431,8 @@ function renderMain() {
 
   if (currentView === 'ubiquitous-language') {
     main.innerHTML = renderUbiquitousLanguageView();
-    void mountUbiquitousLanguage(BASE_URL, selectedContextNames);
+    const allBcNames = (data.boundedContexts || []).map((c) => c.name);
+    void mountUbiquitousLanguage(BASE_URL, selectedContextNames, undefined, allBcNames);
     return;
   }
 

--- a/DomainModeling.AspNetCore/wwwroot/js/tabs.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/tabs.js
@@ -4,7 +4,8 @@
 
 export function renderTabBar(activeTab) {
   const tabs = [
-    { id: 'diagram',       label: 'Diagram' },
+    { id: 'diagram', label: 'Diagram' },
+    { id: 'ubiquitous-language', label: 'Language' },
   ];
 
   if (window.__config?.featureEditorMode) {

--- a/DomainModeling.AspNetCore/wwwroot/js/trace.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/trace.js
@@ -173,7 +173,7 @@ export function clearTracePanel() {
 export function renderTraceView() {
   let html = '<div class="trace-layout">';
   html += '<div class="trace-diagram-pane">';
-  html += renderDiagramView({ traceLayout: true });
+  html += renderDiagramView({ traceLayout: true, activeTab: 'trace' });
   html += '</div>';
   html += '<aside class="trace-panel" id="tracePanel">';
   html += '<div class="trace-panel-header">';

--- a/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
@@ -144,10 +144,14 @@ export function renderUbiquitousLanguageView(opts = {}) {
   const traceLayout = opts.traceLayout === true;
   const activeTab = opts.activeTab || (traceLayout ? 'trace' : 'ubiquitous-language');
   let html = renderTabBar(activeTab);
-  html += '<div class="ul-lang-toolbar" id="ulLangToolbar" style="display:none">';
+  html += '<div class="ul-lang-toolbar" id="ulLangToolbar">';
+  html += '<div class="ul-lang-toolbar-spacer"></div>';
+  html += '<div class="ul-lang-toolbar-inner" id="ulLangToolbarInner" style="display:none">';
   html += '<label class="ul-lang-label" for="ulLangSelect">Language</label>';
   html += '<select id="ulLangSelect" class="ul-lang-select" onchange="window.__ulOnLangChange(this.value)">';
   html += '</select>';
+  html += '</div>';
+  html += '<button type="button" class="ul-download-btn" id="ulDownloadBtn" disabled title="Download Markdown (same pipeline as server export)" onclick="window.__ulDownloadMarkdown()">⬇ Markdown</button>';
   html += '</div>';
   html += '<div class="ubiquitous-lang-page ubiquitous-lang-page--loading" id="ulPageRoot">';
   html += '<p class="ul-loading" id="ulStatus">Loading ubiquitous language…</p>';
@@ -178,8 +182,13 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, req
   const root = document.getElementById('ulPageRoot');
   const status = document.getElementById('ulStatus');
   const toolbar = document.getElementById('ulLangToolbar');
+  const toolbarInner = document.getElementById('ulLangToolbarInner');
   const select = document.getElementById('ulLangSelect');
+  const downloadBtn = document.getElementById('ulDownloadBtn');
   if (!root) return;
+
+  window.__ulDownloadMarkdown = () => {};
+  if (downloadBtn) downloadBtn.disabled = true;
 
   const langParam = requestedLang !== undefined && requestedLang !== null && requestedLang !== ''
     ? requestedLang
@@ -192,15 +201,39 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, req
     const doc = await res.json();
 
     const langs = doc.availableLanguages || [];
-    if (toolbar && select && langs.length > 1) {
-      toolbar.style.display = '';
+    if (toolbarInner && select && langs.length > 1) {
+      toolbarInner.style.display = '';
       const current = doc.language || '';
       select.innerHTML = langs.map((l) =>
         `<option value="${escAttr(l)}"${l === current ? ' selected' : ''}>${esc(l)}</option>`,
       ).join('');
-    } else if (toolbar) {
-      toolbar.style.display = 'none';
+    } else if (toolbarInner) {
+      toolbarInner.style.display = 'none';
     }
+
+    const activeLang = doc.language || '';
+    window.__ulDownloadMarkdown = async () => {
+      const qs = activeLang ? `?lang=${encodeURIComponent(activeLang)}` : '';
+      const mdUrl = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language.md${qs}`;
+      try {
+        const res = await fetch(mdUrl);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const blob = await res.blob();
+        const cd = res.headers.get('Content-Disposition') || '';
+        const m = cd.match(/filename="?([^";]+)"?/i);
+        const filename = m ? m[1] : (activeLang ? `ubiquitous-language-${activeLang}.md` : 'ubiquitous-language.md');
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(a.href);
+      } catch (err) {
+        console.error('Ubiquitous language Markdown download failed', err);
+      }
+    };
+    if (downloadBtn) downloadBtn.disabled = false;
 
     window.__ulOnLangChange = (lang) => {
       setStoredUlLang(lang);

--- a/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
@@ -5,6 +5,7 @@ import { esc, escAttr } from './helpers.js';
 import { renderTabBar } from './tabs.js';
 
 const UL_LANG_KEY = 'domainModelUbiquitousLanguageLang';
+const UL_BC_KEY = 'domainModelUbiquitousLanguageBc';
 
 const REL_COLORS = {
   Has: '#60a5fa',
@@ -20,6 +21,21 @@ function kindPillClass(kindLabel) {
   if (k.includes('sub') && (k.includes('type') || k.includes('typ'))) return 'ul-kind-pill st';
   if (k.includes('aggreg')) return 'ul-kind-pill agg';
   return 'ul-kind-pill';
+}
+
+function getStoredUlBcFilter() {
+  try {
+    return localStorage.getItem(UL_BC_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+function setStoredUlBcFilter(name) {
+  try {
+    if (name) localStorage.setItem(UL_BC_KEY, name);
+    else localStorage.removeItem(UL_BC_KEY);
+  } catch { /* ignore */ }
 }
 
 function renderRelations(relations, labels) {
@@ -144,13 +160,18 @@ export function renderUbiquitousLanguageView(opts = {}) {
   const traceLayout = opts.traceLayout === true;
   const activeTab = opts.activeTab || (traceLayout ? 'trace' : 'ubiquitous-language');
   let html = renderTabBar(activeTab);
-  html += '<div class="ul-lang-toolbar" id="ulLangToolbar">';
-  html += '<div class="ul-lang-toolbar-spacer"></div>';
+  html += '<div class="ul-top-toolbar" id="ulTopToolbar">';
+  html += '<div class="ul-bc-filter-wrap" id="ulBcFilterWrap" style="display:none">';
+  html += '<label class="ul-bc-filter-label" for="ulBcSelect">Bounded context</label>';
+  html += '<select id="ulBcSelect" class="ul-bc-select" onchange="window.__ulOnBcChange(this.value)">';
+  html += '</select>';
+  html += '</div>';
   html += '<div class="ul-lang-toolbar-inner" id="ulLangToolbarInner" style="display:none">';
   html += '<label class="ul-lang-label" for="ulLangSelect">Language</label>';
   html += '<select id="ulLangSelect" class="ul-lang-select" onchange="window.__ulOnLangChange(this.value)">';
   html += '</select>';
   html += '</div>';
+  html += '<div class="ul-toolbar-spacer"></div>';
   html += '<button type="button" class="ul-download-btn" id="ulDownloadBtn" disabled title="Download Markdown (same pipeline as server export)" onclick="window.__ulDownloadMarkdown()">⬇ Markdown</button>';
   html += '</div>';
   html += '<div class="ubiquitous-lang-page ubiquitous-lang-page--loading" id="ulPageRoot">';
@@ -174,14 +195,25 @@ function setStoredUlLang(lang) {
   } catch { /* ignore */ }
 }
 
+function buildUlQuery(lang, contextName) {
+  const params = new URLSearchParams();
+  if (lang) params.set('lang', lang);
+  if (contextName) params.set('context', contextName);
+  const s = params.toString();
+  return s ? `?${s}` : '';
+}
+
 /**
- * @param {string} baseUrl — e.g. <code>/domain-model</code> (no trailing slash)
- * @param {Set<string> | null | undefined} selectedContextNames — when set, only these bounded contexts are shown
+ * @param {string} baseUrl
+ * @param {Set<string> | null | undefined} sidebarSelectedContexts — from sidebar checkboxes (used as default when no Language-tab filter)
+ * @param {string | undefined} requestedLang
+ * @param {string[] | null | undefined} allContextNames — all bounded context names in the graph (for top dropdown)
  */
-export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, requestedLang) {
+export async function mountUbiquitousLanguage(baseUrl, sidebarSelectedContexts, requestedLang, allContextNames) {
   const root = document.getElementById('ulPageRoot');
   const status = document.getElementById('ulStatus');
-  const toolbar = document.getElementById('ulLangToolbar');
+  const bcWrap = document.getElementById('ulBcFilterWrap');
+  const bcSelect = document.getElementById('ulBcSelect');
   const toolbarInner = document.getElementById('ulLangToolbarInner');
   const select = document.getElementById('ulLangSelect');
   const downloadBtn = document.getElementById('ulDownloadBtn');
@@ -190,15 +222,43 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, req
   window.__ulDownloadMarkdown = () => {};
   if (downloadBtn) downloadBtn.disabled = true;
 
+  const names = (allContextNames || []).filter(Boolean);
+  const storedBc = getStoredUlBcFilter();
+  let effectiveBc = '';
+  if (names.length > 1) {
+    if (storedBc && names.includes(storedBc)) {
+      effectiveBc = storedBc;
+    } else if (sidebarSelectedContexts && sidebarSelectedContexts.size === 1) {
+      const only = [...sidebarSelectedContexts][0];
+      effectiveBc = names.includes(only) ? only : '';
+    }
+  }
+
   const langParam = requestedLang !== undefined && requestedLang !== null && requestedLang !== ''
     ? requestedLang
     : getStoredUlLang();
-  const qs = langParam ? `?lang=${encodeURIComponent(langParam)}` : '';
+  const qs = buildUlQuery(langParam, effectiveBc);
   const url = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language${qs}`;
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const doc = await res.json();
+
+    if (bcWrap && bcSelect && names.length > 1) {
+      bcWrap.style.display = '';
+      let optsHtml = '<option value="">All bounded contexts</option>';
+      for (const n of names) {
+        optsHtml += `<option value="${escAttr(n)}"${n === effectiveBc ? ' selected' : ''}>${esc(n)}</option>`;
+      }
+      bcSelect.innerHTML = optsHtml;
+    } else if (bcWrap) {
+      bcWrap.style.display = 'none';
+    }
+
+    window.__ulOnBcChange = (name) => {
+      setStoredUlBcFilter(name);
+      void mountUbiquitousLanguage(baseUrl, sidebarSelectedContexts, langParam, names);
+    };
 
     const langs = doc.availableLanguages || [];
     if (toolbarInner && select && langs.length > 1) {
@@ -213,15 +273,15 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, req
 
     const activeLang = doc.language || '';
     window.__ulDownloadMarkdown = async () => {
-      const qs = activeLang ? `?lang=${encodeURIComponent(activeLang)}` : '';
-      const mdUrl = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language.md${qs}`;
+      const q = buildUlQuery(activeLang, effectiveBc);
+      const mdUrl = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language.md${q}`;
       try {
         const res = await fetch(mdUrl);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const blob = await res.blob();
         const cd = res.headers.get('Content-Disposition') || '';
         const m = cd.match(/filename="?([^";]+)"?/i);
-        const filename = m ? m[1] : (activeLang ? `ubiquitous-language-${activeLang}.md` : 'ubiquitous-language.md');
+        const filename = m ? m[1] : 'ubiquitous-language.md';
         const a = document.createElement('a');
         a.href = URL.createObjectURL(blob);
         a.download = filename;
@@ -237,12 +297,12 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, req
 
     window.__ulOnLangChange = (lang) => {
       setStoredUlLang(lang);
-      void mountUbiquitousLanguage(baseUrl, selectedContextNames, lang);
+      void mountUbiquitousLanguage(baseUrl, sidebarSelectedContexts, lang, names);
     };
 
     let contexts = doc.boundedContexts || [];
-    if (selectedContextNames && selectedContextNames.size > 0) {
-      contexts = contexts.filter((bc) => selectedContextNames.has(bc.name));
+    if (sidebarSelectedContexts && sidebarSelectedContexts.size > 0 && !effectiveBc) {
+      contexts = contexts.filter((bc) => sidebarSelectedContexts.has(bc.name));
     }
 
     const labels = {

--- a/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
@@ -1,0 +1,189 @@
+/**
+ * Ubiquitous language reader tab — fetches structured doc from the API and renders by bounded context.
+ */
+import { esc, escAttr } from './helpers.js';
+import { renderTabBar } from './tabs.js';
+
+const REL_COLORS = {
+  Has: '#60a5fa',
+  HasMany: '#60a5fa',
+  Contains: '#60a5fa',
+  References: '#34d399',
+  ReferencesById: '#34d399',
+};
+
+function kindPillClass(kindLabel) {
+  const k = (kindLabel || '').toLowerCase();
+  if (k.includes('value object')) return 'ul-kind-pill vo';
+  if (k.includes('sub-type')) return 'ul-kind-pill st';
+  if (k.includes('aggregate')) return 'ul-kind-pill agg';
+  return 'ul-kind-pill';
+}
+
+function renderRelations(relations, depth) {
+  const items = relations?.items || [];
+  let html = '<div class="ul-relations">';
+  html += '<h4>Relations</h4>';
+  if (items.length === 0) {
+    html += '<p class="ul-empty" style="padding:0;margin:0 0 4px">None from this concept.</p>';
+  } else {
+    html += '<ul class="ul-rel-list">';
+    for (const r of items) {
+      const color = REL_COLORS[r.kind] || '#94a3b8';
+      const via = r.viaLabel
+        ? `<span class="ul-rel-via">via <code>${esc(r.viaLabel)}</code></span>`
+        : '';
+      html += `<li>
+        <span class="ul-rel-phrase" style="color:${color}">${esc(r.phrase)}</span>
+        <span class="ul-rel-target">${esc(r.targetDisplayName)}</span>
+        ${via}
+      </li>`;
+    }
+    html += '</ul>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function renderConceptBlock(block, depth) {
+  const isRoot = depth === 0;
+  const wrapClass = isRoot ? 'ul-root' : 'ul-nested-block';
+  const headClass = isRoot ? 'ul-root-header' : 'ul-nested-head';
+  let html = `<div class="${wrapClass}" data-depth="${depth}">`;
+
+  if (isRoot) {
+    html += `<div class="${headClass}">`;
+    html += `<h3 class="ul-root-title">${esc(block.displayName)}</h3>`;
+    html += `<div class="ul-root-meta"><span>Aggregate</span> · <code>${esc(block.typeName)}</code></div>`;
+    html += '</div>';
+  } else {
+    html += `<div class="${headClass}">`;
+    html += `<span class="ul-nested-name">${esc(block.displayName)}</span>`;
+    html += `<span class="${kindPillClass(block.kindLabel)}">${esc(block.kindLabel)}</span>`;
+    html += `<div class="ul-root-meta" style="margin-top:0;width:100%"><code>${esc(block.typeName)}</code></div>`;
+    html += '</div>';
+  }
+
+  if (block.description) {
+    html += `<p class="ul-desc">${esc(block.description)}</p>`;
+  }
+
+  html += renderRelations(block.relations, depth);
+
+  const children = block.linkedConcepts || [];
+  if (children.length > 0) {
+    html += '<div class="ul-nested">';
+    for (const ch of children) {
+      html += renderConceptBlock(ch, depth + 1);
+    }
+    html += '</div>';
+  }
+
+  html += '</div>';
+  return html;
+}
+
+function renderBoundedContext(bc) {
+  const safeId = escAttr(bc.name || 'ctx');
+  let html = `<section class="ul-bc" id="ul-bc-${safeId.replace(/[^a-zA-Z0-9_-]/g, '_')}">`;
+  html += '<header class="ul-bc-header">';
+  html += '<div class="ul-bc-icon" aria-hidden="true">◇</div>';
+  html += `<h2>${esc(bc.name)}</h2>`;
+  html += '</header>';
+  html += '<div class="ul-bc-body">';
+
+  html += '<div class="ul-section">';
+  html += '<h3>Aggregates</h3>';
+  if (bc.aggregates?.emptyMessage) {
+    html += `<p class="ul-empty">${esc(bc.aggregates.emptyMessage)}</p>`;
+  } else {
+    for (const root of bc.aggregates.roots || []) {
+      html += renderConceptBlock(root, 0);
+    }
+  }
+  html += '</div>';
+
+  html += '<div class="ul-section">';
+  html += '<h3>Domain events</h3>';
+  if (bc.domainEvents?.emptyMessage) {
+    html += `<p class="ul-empty">${esc(bc.domainEvents.emptyMessage)}</p>`;
+  } else {
+    html += '<div class="ul-events">';
+    for (const ev of bc.domainEvents.items || []) {
+      html += '<article class="ul-event-card">';
+      html += `<h4>${esc(ev.displayName)}</h4>`;
+      if (ev.description) {
+        html += `<p class="ul-desc">${esc(ev.description)}</p>`;
+      }
+      html += `<div class="ul-root-meta"><code>${esc(ev.typeName)}</code></div>`;
+      html += '</article>';
+    }
+    html += '</div>';
+  }
+  html += '</div>';
+
+  html += '</div></section>';
+  return html;
+}
+
+/**
+ * @param {{ traceLayout?: boolean }} [opts]
+ */
+export function renderUbiquitousLanguageView(opts = {}) {
+  const traceLayout = opts.traceLayout === true;
+  const activeTab = opts.activeTab || (traceLayout ? 'trace' : 'ubiquitous-language');
+  let html = renderTabBar(activeTab);
+  html += '<div class="ubiquitous-lang-page ubiquitous-lang-page--loading" id="ulPageRoot">';
+  html += '<p class="ul-loading" id="ulStatus">Loading ubiquitous language…</p>';
+  html += '</div>';
+  return html;
+}
+
+/**
+ * @param {string} baseUrl — e.g. <code>/domain-model</code> (no trailing slash)
+ * @param {Set<string> | null | undefined} selectedContextNames — when set, only these bounded contexts are shown
+ */
+export async function mountUbiquitousLanguage(baseUrl, selectedContextNames) {
+  const root = document.getElementById('ulPageRoot');
+  const status = document.getElementById('ulStatus');
+  if (!root) return;
+
+  const url = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const doc = await res.json();
+
+    let contexts = doc.boundedContexts || [];
+    if (selectedContextNames && selectedContextNames.size > 0) {
+      contexts = contexts.filter((bc) => selectedContextNames.has(bc.name));
+    }
+
+    let html = '';
+    html += '<div class="ul-hero">';
+    html += `<h1>${esc(doc.title || 'Ubiquitous language')}</h1>`;
+    if (doc.introduction) {
+      html += `<p>${esc(doc.introduction)}</p>`;
+    }
+    html += '</div>';
+
+    if (contexts.length === 0) {
+      html += '<p class="ul-empty">No bounded contexts match the current selection (or the model is empty).</p>';
+    } else {
+      for (const bc of contexts) {
+        html += renderBoundedContext(bc);
+      }
+    }
+
+    root.classList.remove('ubiquitous-lang-page--loading');
+    root.innerHTML = html;
+  } catch (e) {
+    console.error('Ubiquitous language load failed', e);
+    if (status) {
+      status.textContent = 'Could not load ubiquitous language. Is the app running the latest DomainModeling.AspNetCore?';
+      status.className = 'ul-error';
+    } else {
+      root.innerHTML = `<p class="ul-error">Could not load ubiquitous language (${esc(String(e.message || e))}).</p>`;
+    }
+  }
+}

--- a/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/ubiquitous-language.js
@@ -4,6 +4,8 @@
 import { esc, escAttr } from './helpers.js';
 import { renderTabBar } from './tabs.js';
 
+const UL_LANG_KEY = 'domainModelUbiquitousLanguageLang';
+
 const REL_COLORS = {
   Has: '#60a5fa',
   HasMany: '#60a5fa',
@@ -14,24 +16,28 @@ const REL_COLORS = {
 
 function kindPillClass(kindLabel) {
   const k = (kindLabel || '').toLowerCase();
-  if (k.includes('value object')) return 'ul-kind-pill vo';
-  if (k.includes('sub-type')) return 'ul-kind-pill st';
-  if (k.includes('aggregate')) return 'ul-kind-pill agg';
+  if (k.includes('value') || k.includes('waarde')) return 'ul-kind-pill vo';
+  if (k.includes('sub') && (k.includes('type') || k.includes('typ'))) return 'ul-kind-pill st';
+  if (k.includes('aggreg')) return 'ul-kind-pill agg';
   return 'ul-kind-pill';
 }
 
-function renderRelations(relations, depth) {
+function renderRelations(relations, labels) {
   const items = relations?.items || [];
+  const relTitle = labels.relationsHeadingLabel || 'Relations';
+  const none = labels.noRelationsMessage || 'None from this concept.';
+  const viaWord = labels.relationshipViaWord || 'via';
+
   let html = '<div class="ul-relations">';
-  html += '<h4>Relations</h4>';
+  html += `<h4>${esc(relTitle)}</h4>`;
   if (items.length === 0) {
-    html += '<p class="ul-empty" style="padding:0;margin:0 0 4px">None from this concept.</p>';
+    html += `<p class="ul-empty" style="padding:0;margin:0 0 4px">${esc(none)}</p>`;
   } else {
     html += '<ul class="ul-rel-list">';
     for (const r of items) {
       const color = REL_COLORS[r.kind] || '#94a3b8';
       const via = r.viaLabel
-        ? `<span class="ul-rel-via">via <code>${esc(r.viaLabel)}</code></span>`
+        ? `<span class="ul-rel-via">${esc(viaWord)} <code>${esc(r.viaLabel)}</code></span>`
         : '';
       html += `<li>
         <span class="ul-rel-phrase" style="color:${color}">${esc(r.phrase)}</span>
@@ -45,22 +51,23 @@ function renderRelations(relations, depth) {
   return html;
 }
 
-function renderConceptBlock(block, depth) {
+function renderConceptBlock(block, depth, labels) {
   const isRoot = depth === 0;
   const wrapClass = isRoot ? 'ul-root' : 'ul-nested-block';
   const headClass = isRoot ? 'ul-root-header' : 'ul-nested-head';
+  const typePrefix = labels.typeLabelPrefix || 'Type';
   let html = `<div class="${wrapClass}" data-depth="${depth}">`;
 
   if (isRoot) {
     html += `<div class="${headClass}">`;
     html += `<h3 class="ul-root-title">${esc(block.displayName)}</h3>`;
-    html += `<div class="ul-root-meta"><span>Aggregate</span> · <code>${esc(block.typeName)}</code></div>`;
+    html += `<div class="ul-root-meta"><span>${esc(block.kindLabel || 'aggregate')}</span> · <code>${esc(block.typeName)}</code></div>`;
     html += '</div>';
   } else {
     html += `<div class="${headClass}">`;
     html += `<span class="ul-nested-name">${esc(block.displayName)}</span>`;
     html += `<span class="${kindPillClass(block.kindLabel)}">${esc(block.kindLabel)}</span>`;
-    html += `<div class="ul-root-meta" style="margin-top:0;width:100%"><code>${esc(block.typeName)}</code></div>`;
+    html += `<div class="ul-root-meta" style="margin-top:0;width:100%"><span>${esc(typePrefix)}</span> · <code>${esc(block.typeName)}</code></div>`;
     html += '</div>';
   }
 
@@ -68,13 +75,13 @@ function renderConceptBlock(block, depth) {
     html += `<p class="ul-desc">${esc(block.description)}</p>`;
   }
 
-  html += renderRelations(block.relations, depth);
+  html += renderRelations(block.relations, labels);
 
   const children = block.linkedConcepts || [];
   if (children.length > 0) {
     html += '<div class="ul-nested">';
     for (const ch of children) {
-      html += renderConceptBlock(ch, depth + 1);
+      html += renderConceptBlock(ch, depth + 1, labels);
     }
     html += '</div>';
   }
@@ -83,8 +90,12 @@ function renderConceptBlock(block, depth) {
   return html;
 }
 
-function renderBoundedContext(bc) {
+function renderBoundedContext(bc, labels) {
   const safeId = escAttr(bc.name || 'ctx');
+  const aggSec = labels.aggregatesSectionLabel || 'Aggregates';
+  const evSec = labels.domainEventsSectionLabel || 'Domain events';
+  const typePrefix = labels.typeLabelPrefix || 'Type';
+
   let html = `<section class="ul-bc" id="ul-bc-${safeId.replace(/[^a-zA-Z0-9_-]/g, '_')}">`;
   html += '<header class="ul-bc-header">';
   html += '<div class="ul-bc-icon" aria-hidden="true">◇</div>';
@@ -93,18 +104,18 @@ function renderBoundedContext(bc) {
   html += '<div class="ul-bc-body">';
 
   html += '<div class="ul-section">';
-  html += '<h3>Aggregates</h3>';
+  html += `<h3>${esc(aggSec)}</h3>`;
   if (bc.aggregates?.emptyMessage) {
     html += `<p class="ul-empty">${esc(bc.aggregates.emptyMessage)}</p>`;
   } else {
     for (const root of bc.aggregates.roots || []) {
-      html += renderConceptBlock(root, 0);
+      html += renderConceptBlock(root, 0, labels);
     }
   }
   html += '</div>';
 
   html += '<div class="ul-section">';
-  html += '<h3>Domain events</h3>';
+  html += `<h3>${esc(evSec)}</h3>`;
   if (bc.domainEvents?.emptyMessage) {
     html += `<p class="ul-empty">${esc(bc.domainEvents.emptyMessage)}</p>`;
   } else {
@@ -115,7 +126,7 @@ function renderBoundedContext(bc) {
       if (ev.description) {
         html += `<p class="ul-desc">${esc(ev.description)}</p>`;
       }
-      html += `<div class="ul-root-meta"><code>${esc(ev.typeName)}</code></div>`;
+      html += `<div class="ul-root-meta"><span>${esc(typePrefix)}</span> · <code>${esc(ev.typeName)}</code></div>`;
       html += '</article>';
     }
     html += '</div>';
@@ -133,35 +144,89 @@ export function renderUbiquitousLanguageView(opts = {}) {
   const traceLayout = opts.traceLayout === true;
   const activeTab = opts.activeTab || (traceLayout ? 'trace' : 'ubiquitous-language');
   let html = renderTabBar(activeTab);
+  html += '<div class="ul-lang-toolbar" id="ulLangToolbar" style="display:none">';
+  html += '<label class="ul-lang-label" for="ulLangSelect">Language</label>';
+  html += '<select id="ulLangSelect" class="ul-lang-select" onchange="window.__ulOnLangChange(this.value)">';
+  html += '</select>';
+  html += '</div>';
   html += '<div class="ubiquitous-lang-page ubiquitous-lang-page--loading" id="ulPageRoot">';
   html += '<p class="ul-loading" id="ulStatus">Loading ubiquitous language…</p>';
   html += '</div>';
   return html;
 }
 
+function getStoredUlLang() {
+  try {
+    return localStorage.getItem(UL_LANG_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+function setStoredUlLang(lang) {
+  try {
+    if (lang) localStorage.setItem(UL_LANG_KEY, lang);
+    else localStorage.removeItem(UL_LANG_KEY);
+  } catch { /* ignore */ }
+}
+
 /**
  * @param {string} baseUrl — e.g. <code>/domain-model</code> (no trailing slash)
  * @param {Set<string> | null | undefined} selectedContextNames — when set, only these bounded contexts are shown
  */
-export async function mountUbiquitousLanguage(baseUrl, selectedContextNames) {
+export async function mountUbiquitousLanguage(baseUrl, selectedContextNames, requestedLang) {
   const root = document.getElementById('ulPageRoot');
   const status = document.getElementById('ulStatus');
+  const toolbar = document.getElementById('ulLangToolbar');
+  const select = document.getElementById('ulLangSelect');
   if (!root) return;
 
-  const url = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language`;
+  const langParam = requestedLang !== undefined && requestedLang !== null && requestedLang !== ''
+    ? requestedLang
+    : getStoredUlLang();
+  const qs = langParam ? `?lang=${encodeURIComponent(langParam)}` : '';
+  const url = `${baseUrl.replace(/\/$/, '')}/ubiquitous-language${qs}`;
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const doc = await res.json();
+
+    const langs = doc.availableLanguages || [];
+    if (toolbar && select && langs.length > 1) {
+      toolbar.style.display = '';
+      const current = doc.language || '';
+      select.innerHTML = langs.map((l) =>
+        `<option value="${escAttr(l)}"${l === current ? ' selected' : ''}>${esc(l)}</option>`,
+      ).join('');
+    } else if (toolbar) {
+      toolbar.style.display = 'none';
+    }
+
+    window.__ulOnLangChange = (lang) => {
+      setStoredUlLang(lang);
+      void mountUbiquitousLanguage(baseUrl, selectedContextNames, lang);
+    };
 
     let contexts = doc.boundedContexts || [];
     if (selectedContextNames && selectedContextNames.size > 0) {
       contexts = contexts.filter((bc) => selectedContextNames.has(bc.name));
     }
 
+    const labels = {
+      aggregatesSectionLabel: doc.aggregatesSectionLabel,
+      domainEventsSectionLabel: doc.domainEventsSectionLabel,
+      relationsHeadingLabel: doc.relationsHeadingLabel,
+      typeLabelPrefix: doc.typeLabelPrefix,
+      noRelationsMessage: doc.noRelationsMessage,
+      relationshipViaWord: doc.relationshipViaWord,
+    };
+
     let html = '';
     html += '<div class="ul-hero">';
     html += `<h1>${esc(doc.title || 'Ubiquitous language')}</h1>`;
+    if (doc.language && langs.length > 1) {
+      html += `<p class="ul-lang-badge">${esc(doc.language)}</p>`;
+    }
     if (doc.introduction) {
       html += `<p>${esc(doc.introduction)}</p>`;
     }
@@ -171,7 +236,7 @@ export async function mountUbiquitousLanguage(baseUrl, selectedContextNames) {
       html += '<p class="ul-empty">No bounded contexts match the current selection (or the model is empty).</p>';
     } else {
       for (const bc of contexts) {
-        html += renderBoundedContext(bc);
+        html += renderBoundedContext(bc, labels);
       }
     }
 

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -54,6 +54,8 @@ builder.Services.AddSingleton<IRepository<Carrier>, CarrierRepository>();
 
 var app = builder.Build();
 
+UbiquitousLanguageDefinition ubiquitousLanguageDefinition = UbiquitousLanguageDefinition.CreateDefault();
+
 // Mount the domain model explorer UI at /domain-model (with developer editor and testing enabled)
 app.MapDomainModel(domainGraph, configure: opts =>
 {
@@ -65,6 +67,32 @@ app.MapDomainModel(domainGraph, configure: opts =>
         .Add()
         .Update()
         .Delete());
+
+    opts.UseUbiquitousLanguage(b => b
+        .UseDefaultLanguage("en")
+        .Language("nl", p => p
+            .WithTitle("Ubiquit taal")
+            .WithIntroduction("Gegenereerd uit het domeinmodel.")
+            .WithMarkdownSectionAggregates("Aggregaten")
+            .WithMarkdownSectionDomainEvents("Domeingebeurtenissen")
+            .WithMarkdownBoundedContextHeadingFormat("Begrensd domein: {0}")
+            .WithNoAggregatesInContext("Geen aggregaten in deze context.")
+            .WithNoDomainEventsInContext("Geen domeingebeurtenissen in deze context.")
+            .WithNoRelationsFromConcept("Geen relaties vanaf dit concept.")
+            .WithMarkdownRelationsHeading("Relaties")
+            .WithMarkdownTypePrefix("Type")
+            .WithMarkdownRelationshipViaWord("via")
+            .WithKindAggregate("aggregaat")
+            .WithKindEntity("entiteit")
+            .WithKindValueObject("waardeobject")
+            .WithKindSubType("subtype")
+            .WithRelationshipHas("heeft")
+            .WithRelationshipHasMany("heeft veel")
+            .WithRelationshipContains("bevat")
+            .WithRelationshipReferences("verwijst naar")
+            .WithRelationshipReferencesById("verwijst naar via id")));
+
+    ubiquitousLanguageDefinition = opts.UbiquitousLanguage;
 
     opts.AddExport("Summary", "txt", graph =>
     {
@@ -81,7 +109,8 @@ app.MapDomainModel(domainGraph, configure: opts =>
         return string.Join(Environment.NewLine, lines);
     });
 
-    opts.AddExport("Ubiquitous Language", "md", UbiquitousLanguageMarkdownExport.Build);
+    opts.AddExport("Ubiquitous Language", "md", graph =>
+        UbiquitousLanguageMarkdownExport.Build(graph, ubiquitousLanguageDefinition, language: null));
 
     opts.AddFeatureExport("Summary", "md", graph =>
     {

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -54,8 +54,6 @@ builder.Services.AddSingleton<IRepository<Carrier>, CarrierRepository>();
 
 var app = builder.Build();
 
-UbiquitousLanguageDefinition ubiquitousLanguageDefinition = UbiquitousLanguageDefinition.CreateDefault();
-
 // Mount the domain model explorer UI at /domain-model (with developer editor and testing enabled)
 app.MapDomainModel(domainGraph, configure: opts =>
 {
@@ -92,8 +90,6 @@ app.MapDomainModel(domainGraph, configure: opts =>
             .WithRelationshipReferences("verwijst naar")
             .WithRelationshipReferencesById("verwijst naar via id")));
 
-    ubiquitousLanguageDefinition = opts.UbiquitousLanguage;
-
     opts.AddExport("Summary", "txt", graph =>
     {
         var lines = new System.Collections.Generic.List<string>();
@@ -108,9 +104,6 @@ app.MapDomainModel(domainGraph, configure: opts =>
         }
         return string.Join(Environment.NewLine, lines);
     });
-
-    opts.AddExport("Ubiquitous Language", "md", graph =>
-        UbiquitousLanguageMarkdownExport.Build(graph, ubiquitousLanguageDefinition, language: null));
 
     opts.AddFeatureExport("Summary", "md", graph =>
     {

--- a/DomainModeling.Example/Program.cs
+++ b/DomainModeling.Example/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using DomainModeling.AspNetCore;
 using DomainModeling.Builder;
+using DomainModeling.Graph;
 using DomainModeling.Example.Application;
 using DomainModeling.Example.Domain;
 using DomainModeling.Example.IntegrationEvents;
@@ -79,6 +80,8 @@ app.MapDomainModel(domainGraph, configure: opts =>
         }
         return string.Join(Environment.NewLine, lines);
     });
+
+    opts.AddExport("Ubiquitous Language", "md", UbiquitousLanguageMarkdownExport.Build);
 
     opts.AddFeatureExport("Summary", "md", graph =>
     {

--- a/DomainModeling.Tests/UbiquitousLanguageContextFilterTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageContextFilterTests.cs
@@ -1,0 +1,47 @@
+using DomainModeling.Graph;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public class UbiquitousLanguageContextFilterTests
+{
+    [Fact]
+    public void Build_WithBoundedContextNames_ReturnsOnlyThoseContexts()
+    {
+        var graph = new DomainGraph(
+            new BoundedContextNode { Name = "A" },
+            new BoundedContextNode { Name = "B" });
+
+        var doc = UbiquitousLanguageDocumentBuilder.Build(
+            graph,
+            UbiquitousLanguageDefinition.CreateDefault(),
+            language: null,
+            boundedContextNames: ["B"]);
+
+        doc.BoundedContexts.Should().ContainSingle().Which.Name.Should().Be("B");
+        doc.FilteredToBoundedContexts.Should().Equal("B");
+    }
+
+    [Fact]
+    public void Markdown_Build_WithFilter_MatchesDocument()
+    {
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "X",
+                Aggregates = [new AggregateNode { Name = "Root", FullName = "X.Root" }],
+            },
+            new BoundedContextNode
+            {
+                Name = "Y",
+                Aggregates = [new AggregateNode { Name = "Other", FullName = "Y.Other" }],
+            });
+
+        var def = UbiquitousLanguageDefinition.CreateDefault();
+        var md = UbiquitousLanguageMarkdownExport.Build(graph, def, language: null, boundedContextNames: ["X"]);
+
+        md.Should().Contain("Bounded context: X");
+        md.Should().NotContain("Bounded context: Y");
+    }
+}

--- a/DomainModeling.Tests/UbiquitousLanguageDefinitionTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageDefinitionTests.cs
@@ -1,0 +1,59 @@
+using DomainModeling.Graph;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public class UbiquitousLanguageDefinitionTests
+{
+    [Fact]
+    public void Builder_AddsLanguage_AndDefaultResolvesPhrases()
+    {
+        var def = UbiquitousLanguageDefinitionBuilder.Create()
+            .UseDefaultLanguage("nl")
+            .Language("nl", p => p.WithTitle("NL titel").WithRelationshipHas("bezit"))
+            .Build();
+
+        def.DefaultLanguage.Should().Be("nl");
+        var phrases = def.ResolvePhrases(null);
+        phrases.Title.Should().Be("NL titel");
+        phrases.RelationshipHas.Should().Be("bezit");
+    }
+
+    [Fact]
+    public void DocumentBuilder_UsesPhrasesForRelationAndSections()
+    {
+        var def = UbiquitousLanguageDefinitionBuilder.Create()
+            .Language("de", p => p
+                .WithMarkdownSectionAggregates("Aggregate")
+                .WithMarkdownSectionDomainEvents("Ereignisse")
+                .WithRelationshipHas("hat"))
+            .Build();
+
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "X",
+                Aggregates =
+                [
+                    new AggregateNode { Name = "A", FullName = "X.A" },
+                ],
+                ValueObjects =
+                [
+                    new ValueObjectNode { Name = "V", FullName = "X.V" },
+                ],
+                Relationships =
+                [
+                    new Relationship { SourceType = "X.A", TargetType = "X.V", Kind = RelationshipKind.Has },
+                ],
+            });
+
+        var doc = UbiquitousLanguageDocumentBuilder.Build(graph, def, "de");
+        doc.Language.Should().Be("de");
+        doc.AvailableLanguages.Should().Contain("de");
+        doc.AggregatesSectionLabel.Should().Be("Aggregate");
+        doc.DomainEventsSectionLabel.Should().Be("Ereignisse");
+        doc.BoundedContexts[0].Aggregates.Roots[0].Relations.Items.Should().ContainSingle()
+            .Which.Phrase.Should().Be("hat");
+    }
+}

--- a/DomainModeling.Tests/UbiquitousLanguageDocumentBuilderTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageDocumentBuilderTests.cs
@@ -33,6 +33,8 @@ public class UbiquitousLanguageDocumentBuilderTests
 
         var doc = UbiquitousLanguageDocumentBuilder.Build(graph);
 
+        doc.Language.Should().Be("en");
+        doc.AvailableLanguages.Should().Contain("en");
         doc.BoundedContexts.Should().ContainSingle().Which.Name.Should().Be("Shop");
         var bc = doc.BoundedContexts[0];
         bc.Aggregates.Roots.Should().ContainSingle().Which.DisplayName.Should().Be("Basket");

--- a/DomainModeling.Tests/UbiquitousLanguageDocumentBuilderTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageDocumentBuilderTests.cs
@@ -1,0 +1,41 @@
+using DomainModeling.Graph;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public class UbiquitousLanguageDocumentBuilderTests
+{
+    [Fact]
+    public void FromJson_RoundTripsBoundedContextName()
+    {
+        var g = new DomainGraph(new BoundedContextNode { Name = "Catalog" });
+        var g2 = DomainGraph.FromJson(g.ToJson());
+        g2.BoundedContexts.Should().ContainSingle().Which.Name.Should().Be("Catalog");
+    }
+
+    [Fact]
+    public void Build_ProducesBoundedContextWithAggregateAndEvent()
+    {
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "Shop",
+                Aggregates =
+                [
+                    new AggregateNode { Name = "Cart", FullName = "Demo.Cart", Alias = "Basket", Description = "A cart." },
+                ],
+                DomainEvents =
+                [
+                    new DomainEventNode { Name = "CartCleared", FullName = "Demo.CartCleared", Description = "Fired when empty." },
+                ],
+            });
+
+        var doc = UbiquitousLanguageDocumentBuilder.Build(graph);
+
+        doc.BoundedContexts.Should().ContainSingle().Which.Name.Should().Be("Shop");
+        var bc = doc.BoundedContexts[0];
+        bc.Aggregates.Roots.Should().ContainSingle().Which.DisplayName.Should().Be("Basket");
+        bc.DomainEvents.Items.Should().ContainSingle().Which.DisplayName.Should().Be("CartCleared");
+    }
+}

--- a/DomainModeling.Tests/UbiquitousLanguageMarkdownExportTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageMarkdownExportTests.cs
@@ -31,6 +31,7 @@ public class UbiquitousLanguageMarkdownExportTests
                         Name = "OrderLine",
                         FullName = orderLineType,
                         Alias = "Line item",
+                        Description = "One product line on an order.",
                     },
                 ],
                 DomainEvents =
@@ -69,7 +70,123 @@ public class UbiquitousLanguageMarkdownExportTests
         md.Should().Contain("`ShipmentRef`");
         md.Should().Contain("**has many**");
         md.Should().Contain("`Line item`");
+        md.Should().Contain("_(entity)_");
+        md.Should().Contain("One product line on an order.");
         md.Should().Contain("#### Order placed");
         md.Should().Contain("Raised when checkout completes.");
+    }
+
+    [Fact]
+    public void Build_DepthLimit_OmitsConceptBlockBeyondFourthHopFromAggregate()
+    {
+        const string deepestMarker = "ONLY_AT_LEVEL_FIVE";
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "Deep",
+                Aggregates =
+                [
+                    new AggregateNode { Name = "Root", FullName = "Demo.Root", Alias = "Root agg" },
+                ],
+                Entities =
+                [
+                    new EntityNode { Name = "E1", FullName = "Demo.E1", Alias = "Hop 1" },
+                    new EntityNode { Name = "E2", FullName = "Demo.E2", Alias = "Hop 2" },
+                    new EntityNode { Name = "E3", FullName = "Demo.E3", Alias = "Hop 3" },
+                    new EntityNode { Name = "E4", FullName = "Demo.E4", Alias = "Hop 4" },
+                    new EntityNode
+                    {
+                        Name = "E5",
+                        FullName = "Demo.E5",
+                        Alias = "Hop 5",
+                        Description = deepestMarker,
+                    },
+                ],
+                Relationships =
+                [
+                    new Relationship { SourceType = "Demo.Root", TargetType = "Demo.E1", Kind = RelationshipKind.Has },
+                    new Relationship { SourceType = "Demo.E1", TargetType = "Demo.E2", Kind = RelationshipKind.Has },
+                    new Relationship { SourceType = "Demo.E2", TargetType = "Demo.E3", Kind = RelationshipKind.Has },
+                    new Relationship { SourceType = "Demo.E3", TargetType = "Demo.E4", Kind = RelationshipKind.Has },
+                    new Relationship { SourceType = "Demo.E4", TargetType = "Demo.E5", Kind = RelationshipKind.Has },
+                ],
+            });
+
+        var md = UbiquitousLanguageMarkdownExport.Build(graph);
+
+        md.Should().Contain("Hop 4");
+        md.Should().NotContain(deepestMarker);
+    }
+
+    [Fact]
+    public void Build_IncludesContainsAndReferencesByIdAndValueObject()
+    {
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "Shop",
+                Aggregates =
+                [
+                    new AggregateNode
+                    {
+                        Name = "Cart",
+                        FullName = "Demo.Cart",
+                        Alias = "Shopping cart",
+                        ChildEntities = ["Demo.CartLine"],
+                    },
+                ],
+                Entities =
+                [
+                    new EntityNode
+                    {
+                        Name = "CartLine",
+                        FullName = "Demo.CartLine",
+                        Alias = "Cart line",
+                        Description = "One row in the cart.",
+                    },
+                ],
+                ValueObjects =
+                [
+                    new ValueObjectNode
+                    {
+                        Name = "Sku",
+                        FullName = "Demo.Sku",
+                        Alias = "Stock keeping unit",
+                        Description = "Product identifier in catalog.",
+                    },
+                ],
+                Relationships =
+                [
+                    new Relationship
+                    {
+                        SourceType = "Demo.Cart",
+                        TargetType = "Demo.CartLine",
+                        Kind = RelationshipKind.Contains,
+                        Label = "contains",
+                    },
+                    new Relationship
+                    {
+                        SourceType = "Demo.CartLine",
+                        TargetType = "Demo.Sku",
+                        Kind = RelationshipKind.Has,
+                    },
+                    new Relationship
+                    {
+                        SourceType = "Demo.CartLine",
+                        TargetType = "Demo.Product",
+                        Kind = RelationshipKind.ReferencesById,
+                        Label = "ProductId",
+                    },
+                ],
+            });
+
+        var md = UbiquitousLanguageMarkdownExport.Build(graph);
+
+        md.Should().Contain("**contains**");
+        md.Should().Contain("`Cart line`");
+        md.Should().Contain("**references by id**");
+        md.Should().Contain("_(via `ProductId`)_");
+        md.Should().Contain("_(value object)_");
+        md.Should().Contain("Stock keeping unit");
     }
 }

--- a/DomainModeling.Tests/UbiquitousLanguageMarkdownExportTests.cs
+++ b/DomainModeling.Tests/UbiquitousLanguageMarkdownExportTests.cs
@@ -1,0 +1,75 @@
+using DomainModeling.Graph;
+using FluentAssertions;
+using Xunit;
+
+namespace DomainModeling.Tests;
+
+public class UbiquitousLanguageMarkdownExportTests
+{
+    [Fact]
+    public void Build_IncludesAggregateAliasDescriptionsHasAndHasManyAndDomainEvents()
+    {
+        var orderLineType = "Demo.OrderLine";
+        var graph = new DomainGraph(
+            new BoundedContextNode
+            {
+                Name = "Orders",
+                Aggregates =
+                [
+                    new AggregateNode
+                    {
+                        Name = "Order",
+                        FullName = "Demo.Order",
+                        Alias = "Customer order",
+                        Description = "A placed order in the system.",
+                    },
+                ],
+                Entities =
+                [
+                    new EntityNode
+                    {
+                        Name = "OrderLine",
+                        FullName = orderLineType,
+                        Alias = "Line item",
+                    },
+                ],
+                DomainEvents =
+                [
+                    new DomainEventNode
+                    {
+                        Name = "OrderPlacedEvent",
+                        FullName = "Demo.OrderPlacedEvent",
+                        Alias = "Order placed",
+                        Description = "Raised when checkout completes.",
+                    },
+                ],
+                Relationships =
+                [
+                    new Relationship
+                    {
+                        SourceType = "Demo.Order",
+                        TargetType = orderLineType,
+                        Kind = RelationshipKind.HasMany,
+                    },
+                    new Relationship
+                    {
+                        SourceType = "Demo.Order",
+                        TargetType = "Demo.ShipmentRef",
+                        Kind = RelationshipKind.Has,
+                    },
+                ],
+            });
+
+        var md = UbiquitousLanguageMarkdownExport.Build(graph);
+
+        md.Should().Contain("## Bounded context: Orders");
+        md.Should().Contain("#### Customer order");
+        md.Should().Contain("A placed order in the system.");
+        md.Should().Contain("**has**");
+        md.Should().Contain("`ShipmentRef`");
+        md.Should().Contain("**has many**");
+        md.Should().Contain("`Line item`");
+        md.Should().Contain("#### Order placed");
+        md.Should().Contain("Raised when checkout completes.");
+    }
+}

--- a/DomainModeling/Graph/DomainGraph.cs
+++ b/DomainModeling/Graph/DomainGraph.cs
@@ -10,9 +10,13 @@ public sealed class DomainGraph
 {
     public List<BoundedContextNode> BoundedContexts { get; init; }
 
-    internal DomainGraph(List<BoundedContextNode> boundedContexts)
+    /// <summary>
+    /// Creates a graph from a list (used by the builder and JSON deserialization).
+    /// </summary>
+    [JsonConstructor]
+    public DomainGraph(List<BoundedContextNode> boundedContexts)
     {
-        BoundedContexts = boundedContexts;
+        BoundedContexts = boundedContexts ?? [];
     }
 
     /// <summary>
@@ -20,7 +24,7 @@ public sealed class DomainGraph
     /// </summary>
     public DomainGraph(params BoundedContextNode[] boundedContexts)
     {
-        BoundedContexts = [..boundedContexts];
+        BoundedContexts = boundedContexts is { Length: > 0 } ? [..boundedContexts] : [];
     }
 
     /// <summary>
@@ -29,6 +33,18 @@ public sealed class DomainGraph
     public string ToJson()
     {
         return System.Text.Json.JsonSerializer.Serialize(this, JsonOptions.Default);
+    }
+
+    /// <summary>
+    /// Deserializes a domain graph from JSON produced by <see cref="ToJson"/> (e.g. after developer edits).
+    /// </summary>
+    public static DomainGraph FromJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        var graph = System.Text.Json.JsonSerializer.Deserialize<DomainGraph>(json, JsonOptions.Default);
+        if (graph is null || graph.BoundedContexts is null)
+            throw new System.Text.Json.JsonException("Invalid domain graph JSON.");
+        return graph;
     }
 }
 

--- a/DomainModeling/Graph/UbiquitousLanguageDefinition.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageDefinition.cs
@@ -1,0 +1,386 @@
+namespace DomainModeling.Graph;
+
+/// <summary>
+/// Localized UI strings for ubiquitous language documents (Markdown, JSON API, custom exporters).
+/// </summary>
+public sealed class UbiquitousLanguagePhrases
+{
+    public required string Title { get; init; }
+    public required string Introduction { get; init; }
+
+    public required string MarkdownSectionAggregates { get; init; }
+    public required string MarkdownSectionDomainEvents { get; init; }
+
+    /// <summary>Format string with <c>{0}</c> = bounded context name (Markdown).</summary>
+    public required string MarkdownBoundedContextHeadingFormat { get; init; }
+
+    public required string NoAggregatesInContext { get; init; }
+    public required string NoDomainEventsInContext { get; init; }
+    public required string NoRelationsFromConcept { get; init; }
+
+    public required string MarkdownRelationsHeading { get; init; }
+    public required string MarkdownTypePrefix { get; init; }
+    public required string MarkdownRelationshipViaWord { get; init; }
+
+    public required string KindAggregate { get; init; }
+    public required string KindEntity { get; init; }
+    public required string KindValueObject { get; init; }
+    public required string KindSubType { get; init; }
+
+    public required string RelationshipHas { get; init; }
+    public required string RelationshipHasMany { get; init; }
+    public required string RelationshipContains { get; init; }
+    public required string RelationshipReferences { get; init; }
+    public required string RelationshipReferencesById { get; init; }
+
+    /// <summary>
+    /// Default English phrases used by <see cref="UbiquitousLanguageDefinition.CreateDefault"/>.
+    /// </summary>
+    public static UbiquitousLanguagePhrases English() => new()
+    {
+        Title = "Ubiquitous language",
+        Introduction =
+            "Generated from the domain model: aggregates with linked entities, value objects, and sub-types (structural relations, limited depth), then domain events — grouped by bounded context.",
+        MarkdownSectionAggregates = "Aggregates",
+        MarkdownSectionDomainEvents = "Domain events",
+        MarkdownBoundedContextHeadingFormat = "Bounded context: {0}",
+        NoAggregatesInContext = "No aggregates in this bounded context.",
+        NoDomainEventsInContext = "No domain events in this bounded context.",
+        NoRelationsFromConcept = "None from this concept.",
+        MarkdownRelationsHeading = "Relations",
+        MarkdownTypePrefix = "Type",
+        MarkdownRelationshipViaWord = "via",
+        KindAggregate = "aggregate",
+        KindEntity = "entity",
+        KindValueObject = "value object",
+        KindSubType = "sub-type",
+        RelationshipHas = "has",
+        RelationshipHasMany = "has many",
+        RelationshipContains = "contains",
+        RelationshipReferences = "references",
+        RelationshipReferencesById = "references by id",
+    };
+
+    internal string RelationshipPhrase(RelationshipKind kind) => kind switch
+    {
+        RelationshipKind.Has => RelationshipHas,
+        RelationshipKind.HasMany => RelationshipHasMany,
+        RelationshipKind.Contains => RelationshipContains,
+        RelationshipKind.References => RelationshipReferences,
+        RelationshipKind.ReferencesById => RelationshipReferencesById,
+        _ => kind.ToString(),
+    };
+
+    internal string KindLabelFor(string internalKind) => internalKind switch
+    {
+        "aggregate" => KindAggregate,
+        "entity" => KindEntity,
+        "value object" => KindValueObject,
+        "sub-type" => KindSubType,
+        _ => internalKind,
+    };
+}
+
+/// <summary>
+/// Defines localized phrase sets for ubiquitous language output. Hosts can replace the default or add languages.
+/// </summary>
+public sealed class UbiquitousLanguageDefinition
+{
+    /// <summary>BCP 47 or short key (e.g. <c>en</c>, <c>nl</c>) used when no language is requested.</summary>
+    public required string DefaultLanguage { get; init; }
+
+    /// <summary>Phrase set per language key.</summary>
+    public required IReadOnlyDictionary<string, UbiquitousLanguagePhrases> Languages { get; init; }
+
+    /// <summary>Maximum hops from an aggregate root into linked concepts.</summary>
+    public int MaxConceptDepth { get; init; } = 4;
+
+    /// <summary>
+    /// Default definition (English only), used when hosts do not call <see cref="DomainModelOptions.UseUbiquitousLanguage"/>.
+    /// </summary>
+    public static UbiquitousLanguageDefinition CreateDefault() => new()
+    {
+        DefaultLanguage = "en",
+        Languages = new Dictionary<string, UbiquitousLanguagePhrases>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["en"] = UbiquitousLanguagePhrases.English(),
+        },
+    };
+
+    internal UbiquitousLanguagePhrases ResolvePhrases(string? requestedLanguage)
+    {
+        var key = string.IsNullOrWhiteSpace(requestedLanguage) ? DefaultLanguage : requestedLanguage.Trim();
+        if (Languages.TryGetValue(key, out var direct))
+            return direct;
+
+        foreach (var kv in Languages)
+        {
+            if (string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase))
+                return kv.Value;
+        }
+
+        return Languages.TryGetValue(DefaultLanguage, out var fallback)
+            ? fallback
+            : Languages.Values.First();
+    }
+
+    internal IReadOnlyList<string> LanguageKeys => Languages.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+}
+
+/// <summary>
+/// Fluent builder for <see cref="UbiquitousLanguageDefinition"/> — customize defaults and add translations.
+/// </summary>
+public sealed class UbiquitousLanguageDefinitionBuilder
+{
+    private string _defaultLanguage = "en";
+    private int _maxDepth = 4;
+    private readonly Dictionary<string, UbiquitousLanguagePhrases> _languages = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Starts a new builder (English is added automatically in <see cref="Build"/> if no languages were registered).</summary>
+    public static UbiquitousLanguageDefinitionBuilder Create() => new();
+
+    /// <summary>
+    /// Sets the language key returned when clients omit <c>?lang=</c> (must exist in <see cref="Language"/> registrations).
+    /// </summary>
+    public UbiquitousLanguageDefinitionBuilder UseDefaultLanguage(string languageKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(languageKey);
+        _defaultLanguage = languageKey.Trim();
+        return this;
+    }
+
+    /// <summary>
+    /// Overrides maximum nesting depth from aggregate roots (default 4).
+    /// </summary>
+    public UbiquitousLanguageDefinitionBuilder WithMaxConceptDepth(int depth)
+    {
+        if (depth < 1)
+            throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1.");
+        _maxDepth = depth;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers or replaces phrases for a language. New languages start from a copy of English unless
+    /// <paramref name="cloneFrom"/> names another existing key to use as a template.
+    /// </summary>
+    public UbiquitousLanguageDefinitionBuilder Language(
+        string languageKey,
+        Action<UbiquitousLanguagePhrasesBuilder> configure,
+        string? cloneFrom = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(languageKey);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var templateKey = string.IsNullOrWhiteSpace(cloneFrom) ? "en" : cloneFrom!;
+        if (!_languages.TryGetValue(templateKey, out var template))
+            template = UbiquitousLanguagePhrases.English();
+
+        var pb = new UbiquitousLanguagePhrasesBuilder(template);
+        configure(pb);
+        _languages[languageKey.Trim()] = pb.Build();
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the definition. Ensures <see cref="UbiquitousLanguageDefinition.DefaultLanguage"/> has a phrase set
+    /// (seeds <c>en</c> from <see cref="UbiquitousLanguagePhrases.English"/> when missing).
+    /// </summary>
+    public UbiquitousLanguageDefinition Build()
+    {
+        if (!_languages.ContainsKey("en") &&
+            !_languages.Keys.Any(k => string.Equals(k, "en", StringComparison.OrdinalIgnoreCase)))
+        {
+            _languages["en"] = UbiquitousLanguagePhrases.English();
+        }
+
+        if (!_languages.ContainsKey(_defaultLanguage) &&
+            !_languages.Keys.Any(k => string.Equals(k, _defaultLanguage, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Ubiquitous language default language '{_defaultLanguage}' has no phrase set. Call Language(\"{_defaultLanguage}\", ...) or UseDefaultLanguage with an existing key.");
+        }
+
+        var normalizedDefault = _languages.Keys.First(k =>
+            string.Equals(k, _defaultLanguage, StringComparison.OrdinalIgnoreCase));
+
+        return new UbiquitousLanguageDefinition
+        {
+            DefaultLanguage = normalizedDefault,
+            Languages = new Dictionary<string, UbiquitousLanguagePhrases>(_languages, StringComparer.OrdinalIgnoreCase),
+            MaxConceptDepth = _maxDepth,
+        };
+    }
+}
+
+/// <summary>
+/// Mutable builder for one <see cref="UbiquitousLanguagePhrases"/> instance.
+/// </summary>
+public sealed class UbiquitousLanguagePhrasesBuilder(UbiquitousLanguagePhrases copyFrom)
+{
+    private string _title = copyFrom.Title;
+    private string _introduction = copyFrom.Introduction;
+    private string _mdAgg = copyFrom.MarkdownSectionAggregates;
+    private string _mdEv = copyFrom.MarkdownSectionDomainEvents;
+    private string _mdBc = copyFrom.MarkdownBoundedContextHeadingFormat;
+    private string _noAgg = copyFrom.NoAggregatesInContext;
+    private string _noEv = copyFrom.NoDomainEventsInContext;
+    private string _noRel = copyFrom.NoRelationsFromConcept;
+    private string _mdRel = copyFrom.MarkdownRelationsHeading;
+    private string _mdType = copyFrom.MarkdownTypePrefix;
+    private string _mdVia = copyFrom.MarkdownRelationshipViaWord;
+    private string _kAgg = copyFrom.KindAggregate;
+    private string _kEnt = copyFrom.KindEntity;
+    private string _kVo = copyFrom.KindValueObject;
+    private string _kSt = copyFrom.KindSubType;
+    private string _rHas = copyFrom.RelationshipHas;
+    private string _rMany = copyFrom.RelationshipHasMany;
+    private string _rCon = copyFrom.RelationshipContains;
+    private string _rRef = copyFrom.RelationshipReferences;
+    private string _rId = copyFrom.RelationshipReferencesById;
+
+    public UbiquitousLanguagePhrasesBuilder WithTitle(string value)
+    {
+        _title = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithIntroduction(string value)
+    {
+        _introduction = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownSectionAggregates(string value)
+    {
+        _mdAgg = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownSectionDomainEvents(string value)
+    {
+        _mdEv = value;
+        return this;
+    }
+
+    /// <summary>Format with <c>{0}</c> replaced by bounded context name for Markdown.</summary>
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownBoundedContextHeadingFormat(string value)
+    {
+        _mdBc = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithNoAggregatesInContext(string value)
+    {
+        _noAgg = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithNoDomainEventsInContext(string value)
+    {
+        _noEv = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithNoRelationsFromConcept(string value)
+    {
+        _noRel = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownRelationsHeading(string value)
+    {
+        _mdRel = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownTypePrefix(string value)
+    {
+        _mdType = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithMarkdownRelationshipViaWord(string value)
+    {
+        _mdVia = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithKindAggregate(string value)
+    {
+        _kAgg = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithKindEntity(string value)
+    {
+        _kEnt = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithKindValueObject(string value)
+    {
+        _kVo = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithKindSubType(string value)
+    {
+        _kSt = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithRelationshipHas(string value)
+    {
+        _rHas = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithRelationshipHasMany(string value)
+    {
+        _rMany = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithRelationshipContains(string value)
+    {
+        _rCon = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithRelationshipReferences(string value)
+    {
+        _rRef = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrasesBuilder WithRelationshipReferencesById(string value)
+    {
+        _rId = value;
+        return this;
+    }
+
+    public UbiquitousLanguagePhrases Build() => new()
+    {
+        Title = _title,
+        Introduction = _introduction,
+        MarkdownSectionAggregates = _mdAgg,
+        MarkdownSectionDomainEvents = _mdEv,
+        MarkdownBoundedContextHeadingFormat = _mdBc,
+        NoAggregatesInContext = _noAgg,
+        NoDomainEventsInContext = _noEv,
+        NoRelationsFromConcept = _noRel,
+        MarkdownRelationsHeading = _mdRel,
+        MarkdownTypePrefix = _mdType,
+        MarkdownRelationshipViaWord = _mdVia,
+        KindAggregate = _kAgg,
+        KindEntity = _kEnt,
+        KindValueObject = _kVo,
+        KindSubType = _kSt,
+        RelationshipHas = _rHas,
+        RelationshipHasMany = _rMany,
+        RelationshipContains = _rCon,
+        RelationshipReferences = _rRef,
+        RelationshipReferencesById = _rId,
+    };
+}

--- a/DomainModeling/Graph/UbiquitousLanguageDocument.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageDocument.cs
@@ -11,6 +11,12 @@ public sealed class UbiquitousLanguageDocument
     /// <summary>Languages the host registered (for UI pickers).</summary>
     public IReadOnlyList<string> AvailableLanguages { get; init; } = [];
 
+    /// <summary>
+    /// When the client requested a bounded-context filter, lists the names that were applied (subset of the full graph).
+    /// <c>null</c> when the full model is included.
+    /// </summary>
+    public List<string>? FilteredToBoundedContexts { get; init; }
+
     public required string Title { get; init; }
     public string? Introduction { get; init; }
 
@@ -113,7 +119,18 @@ public static class UbiquitousLanguageDocumentBuilder
     public static UbiquitousLanguageDocument Build(
         DomainGraph graph,
         UbiquitousLanguageDefinition definition,
-        string? language)
+        string? language) =>
+        Build(graph, definition, language, boundedContextNames: null);
+
+    /// <summary>
+    /// Produces a structured document, optionally restricted to the given bounded context names (case-insensitive).
+    /// When <paramref name="boundedContextNames"/> is null or empty, the full graph is used.
+    /// </summary>
+    public static UbiquitousLanguageDocument Build(
+        DomainGraph graph,
+        UbiquitousLanguageDefinition definition,
+        string? language,
+        IReadOnlyList<string>? boundedContextNames)
     {
         ArgumentNullException.ThrowIfNull(graph);
         ArgumentNullException.ThrowIfNull(definition);
@@ -121,7 +138,7 @@ public static class UbiquitousLanguageDocumentBuilder
         var resolvedLang = string.IsNullOrWhiteSpace(language) ? definition.DefaultLanguage : language.Trim();
         var phrases = definition.ResolvePhrases(resolvedLang);
         var impl = new Impl(definition, phrases, resolvedLang);
-        return impl.Build(graph);
+        return impl.Build(graph, boundedContextNames);
     }
 
     private sealed class Impl(UbiquitousLanguageDefinition definition, UbiquitousLanguagePhrases phrases, string resolvedLang)
@@ -137,16 +154,31 @@ public static class UbiquitousLanguageDocumentBuilder
             RelationshipKind.ReferencesById,
         ];
 
-        public UbiquitousLanguageDocument Build(DomainGraph graph)
+        public UbiquitousLanguageDocument Build(DomainGraph graph, IReadOnlyList<string>? boundedContextNames)
         {
+            List<string>? filterApplied = null;
+            IEnumerable<BoundedContextNode> sourceContexts = graph.BoundedContexts;
+            if (boundedContextNames is { Count: > 0 })
+            {
+                var wanted = new HashSet<string>(
+                    boundedContextNames.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()),
+                    StringComparer.OrdinalIgnoreCase);
+                if (wanted.Count > 0)
+                {
+                    sourceContexts = graph.BoundedContexts.Where(c => wanted.Contains(c.Name)).ToList();
+                    filterApplied = sourceContexts.Select(c => c.Name).ToList();
+                }
+            }
+
             var contexts = new List<UbiquitousLanguageBoundedContext>();
-            foreach (var ctx in graph.BoundedContexts)
+            foreach (var ctx in sourceContexts)
                 contexts.Add(BuildBoundedContext(ctx));
 
             return new UbiquitousLanguageDocument
             {
                 Language = resolvedLang,
                 AvailableLanguages = definition.LanguageKeys,
+                FilteredToBoundedContexts = filterApplied,
                 Title = phrases.Title,
                 Introduction = phrases.Introduction,
                 AggregatesSectionLabel = phrases.MarkdownSectionAggregates,

--- a/DomainModeling/Graph/UbiquitousLanguageDocument.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageDocument.cs
@@ -5,8 +5,36 @@ namespace DomainModeling.Graph;
 /// </summary>
 public sealed class UbiquitousLanguageDocument
 {
+    /// <summary>BCP 47 or custom key for the phrase set used to build this document.</summary>
+    public required string Language { get; init; }
+
+    /// <summary>Languages the host registered (for UI pickers).</summary>
+    public IReadOnlyList<string> AvailableLanguages { get; init; } = [];
+
     public required string Title { get; init; }
     public string? Introduction { get; init; }
+
+    /// <summary>Section title for aggregates (localized).</summary>
+    public required string AggregatesSectionLabel { get; init; }
+
+    /// <summary>Section title for domain events (localized).</summary>
+    public required string DomainEventsSectionLabel { get; init; }
+
+    /// <summary>Heading for the relations list under each concept (localized).</summary>
+    public required string RelationsHeadingLabel { get; init; }
+
+    /// <summary>Prefix before CLR type short name (localized, e.g. "Type").</summary>
+    public required string TypeLabelPrefix { get; init; }
+
+    /// <summary>Message when a concept has no structural outgoing relations.</summary>
+    public required string NoRelationsMessage { get; init; }
+
+    /// <summary>Format string with <c>{0}</c> = bounded context name (Markdown <c>##</c> line).</summary>
+    public required string BoundedContextMarkdownHeadingFormat { get; init; }
+
+    /// <summary>Word before property labels in relation lines (Markdown), e.g. English "via".</summary>
+    public required string RelationshipViaWord { get; init; }
+
     public List<UbiquitousLanguageBoundedContext> BoundedContexts { get; init; } = [];
 }
 
@@ -69,296 +97,315 @@ public sealed class UbiquitousLanguageDomainEventItem
 }
 
 /// <summary>
-/// Builds <see cref="UbiquitousLanguageDocument"/> from a domain graph (same rules as Markdown export).
+/// Builds <see cref="UbiquitousLanguageDocument"/> from a domain graph using <see cref="UbiquitousLanguageDefinition"/> phrases.
 /// </summary>
 public static class UbiquitousLanguageDocumentBuilder
 {
-    private const int MaxConceptDepth = 4;
-
-    private static readonly HashSet<RelationshipKind> StructuralOutgoingKinds =
-    [
-        RelationshipKind.Has,
-        RelationshipKind.HasMany,
-        RelationshipKind.Contains,
-        RelationshipKind.References,
-        RelationshipKind.ReferencesById,
-    ];
+    /// <summary>
+    /// Produces a structured document for APIs and renderers using the default English definition.
+    /// </summary>
+    public static UbiquitousLanguageDocument Build(DomainGraph graph) =>
+        Build(graph, UbiquitousLanguageDefinition.CreateDefault(), language: null);
 
     /// <summary>
-    /// Produces a structured document for APIs and renderers.
+    /// Produces a structured document with optional custom definition and language key (<c>null</c> = definition default).
     /// </summary>
-    public static UbiquitousLanguageDocument Build(DomainGraph graph)
+    public static UbiquitousLanguageDocument Build(
+        DomainGraph graph,
+        UbiquitousLanguageDefinition definition,
+        string? language)
     {
         ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(definition);
 
-        var contexts = new List<UbiquitousLanguageBoundedContext>();
-        foreach (var ctx in graph.BoundedContexts)
-            contexts.Add(BuildBoundedContext(ctx));
-
-        return new UbiquitousLanguageDocument
-        {
-            Title = "Ubiquitous language",
-            Introduction =
-                "Generated from the domain model: aggregates with linked entities, value objects, and sub-types (structural relations, limited depth), then domain events — grouped by bounded context.",
-            BoundedContexts = contexts,
-        };
+        var resolvedLang = string.IsNullOrWhiteSpace(language) ? definition.DefaultLanguage : language.Trim();
+        var phrases = definition.ResolvePhrases(resolvedLang);
+        var impl = new Impl(definition, phrases, resolvedLang);
+        return impl.Build(graph);
     }
 
-    private static UbiquitousLanguageBoundedContext BuildBoundedContext(BoundedContextNode ctx)
+    private sealed class Impl(UbiquitousLanguageDefinition definition, UbiquitousLanguagePhrases phrases, string resolvedLang)
     {
-        UbiquitousLanguageAggregateSection aggregateSection;
-        if (ctx.Aggregates.Count == 0)
+        private readonly int _maxDepth = definition.MaxConceptDepth;
+
+        private static readonly HashSet<RelationshipKind> StructuralOutgoingKinds =
+        [
+            RelationshipKind.Has,
+            RelationshipKind.HasMany,
+            RelationshipKind.Contains,
+            RelationshipKind.References,
+            RelationshipKind.ReferencesById,
+        ];
+
+        public UbiquitousLanguageDocument Build(DomainGraph graph)
         {
-            aggregateSection = new UbiquitousLanguageAggregateSection
+            var contexts = new List<UbiquitousLanguageBoundedContext>();
+            foreach (var ctx in graph.BoundedContexts)
+                contexts.Add(BuildBoundedContext(ctx));
+
+            return new UbiquitousLanguageDocument
             {
-                EmptyMessage = "No aggregates in this bounded context.",
+                Language = resolvedLang,
+                AvailableLanguages = definition.LanguageKeys,
+                Title = phrases.Title,
+                Introduction = phrases.Introduction,
+                AggregatesSectionLabel = phrases.MarkdownSectionAggregates,
+                DomainEventsSectionLabel = phrases.MarkdownSectionDomainEvents,
+                RelationsHeadingLabel = phrases.MarkdownRelationsHeading,
+                TypeLabelPrefix = phrases.MarkdownTypePrefix,
+                NoRelationsMessage = phrases.NoRelationsFromConcept,
+                BoundedContextMarkdownHeadingFormat = phrases.MarkdownBoundedContextHeadingFormat,
+                RelationshipViaWord = phrases.MarkdownRelationshipViaWord,
+                BoundedContexts = contexts,
             };
         }
-        else
-        {
-            var displayByFullName = BuildDisplayLookup(ctx);
-            var typeMaps = TypeMaps.ForContext(ctx);
-            var roots = new List<UbiquitousLanguageConceptBlock>();
-            foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
-                roots.Add(BuildAggregateTree(ctx, aggregate, displayByFullName, typeMaps));
 
-            aggregateSection = new UbiquitousLanguageAggregateSection { Roots = roots };
-        }
-
-        UbiquitousLanguageDomainEventsSection eventsSection;
-        if (ctx.DomainEvents.Count == 0)
+        private UbiquitousLanguageBoundedContext BuildBoundedContext(BoundedContextNode ctx)
         {
-            eventsSection = new UbiquitousLanguageDomainEventsSection
+            UbiquitousLanguageAggregateSection aggregateSection;
+            if (ctx.Aggregates.Count == 0)
             {
-                EmptyMessage = "No domain events in this bounded context.",
-            };
-        }
-        else
-        {
-            var items = ctx.DomainEvents
-                .OrderBy(e => DisplayName(e), StringComparer.OrdinalIgnoreCase)
-                .Select(e => new UbiquitousLanguageDomainEventItem
+                aggregateSection = new UbiquitousLanguageAggregateSection
                 {
-                    DisplayName = DisplayName(e),
-                    TypeName = e.Name,
-                    FullName = e.FullName,
-                    Description = string.IsNullOrWhiteSpace(e.Description) ? null : e.Description.Trim(),
+                    EmptyMessage = phrases.NoAggregatesInContext,
+                };
+            }
+            else
+            {
+                var displayByFullName = BuildDisplayLookup(ctx);
+                var typeMaps = TypeMaps.ForContext(ctx);
+                var roots = new List<UbiquitousLanguageConceptBlock>();
+                foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
+                    roots.Add(BuildAggregateTree(ctx, aggregate, displayByFullName, typeMaps));
+
+                aggregateSection = new UbiquitousLanguageAggregateSection { Roots = roots };
+            }
+
+            UbiquitousLanguageDomainEventsSection eventsSection;
+            if (ctx.DomainEvents.Count == 0)
+            {
+                eventsSection = new UbiquitousLanguageDomainEventsSection
+                {
+                    EmptyMessage = phrases.NoDomainEventsInContext,
+                };
+            }
+            else
+            {
+                var items = ctx.DomainEvents
+                    .OrderBy(e => DisplayName(e), StringComparer.OrdinalIgnoreCase)
+                    .Select(e => new UbiquitousLanguageDomainEventItem
+                    {
+                        DisplayName = DisplayName(e),
+                        TypeName = e.Name,
+                        FullName = e.FullName,
+                        Description = string.IsNullOrWhiteSpace(e.Description) ? null : e.Description.Trim(),
+                    })
+                    .ToList();
+                eventsSection = new UbiquitousLanguageDomainEventsSection { Items = items };
+            }
+
+            return new UbiquitousLanguageBoundedContext
+            {
+                Name = ctx.Name,
+                Aggregates = aggregateSection,
+                DomainEvents = eventsSection,
+            };
+        }
+
+        private UbiquitousLanguageConceptBlock BuildAggregateTree(
+            BoundedContextNode ctx,
+            AggregateNode aggregate,
+            Dictionary<string, string> displayByFullName,
+            TypeMaps maps)
+        {
+            var visited = new HashSet<string>(StringComparer.Ordinal) { aggregate.FullName };
+            var relations = BuildRelationsBlock(ctx, aggregate.FullName, displayByFullName);
+            var linked = BuildLinkedConcepts(ctx, aggregate.FullName, displayByFullName, maps, visited, depth: 1);
+
+            return new UbiquitousLanguageConceptBlock
+            {
+                Depth = 0,
+                DisplayName = DisplayName(aggregate),
+                KindLabel = phrases.KindAggregate,
+                TypeName = aggregate.Name,
+                FullName = aggregate.FullName,
+                Description = string.IsNullOrWhiteSpace(aggregate.Description) ? null : aggregate.Description.Trim(),
+                Relations = relations,
+                LinkedConcepts = linked,
+            };
+        }
+
+        private List<UbiquitousLanguageConceptBlock> BuildLinkedConcepts(
+            BoundedContextNode ctx,
+            string sourceFullName,
+            Dictionary<string, string> displayByFullName,
+            TypeMaps maps,
+            HashSet<string> visited,
+            int depth)
+        {
+            if (depth >= _maxDepth)
+                return [];
+
+            var relations = ctx.Relationships
+                .Where(r =>
+                    string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
+                    StructuralOutgoingKinds.Contains(r.Kind))
+                .OrderBy(r => r.Kind)
+                .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var list = new List<UbiquitousLanguageConceptBlock>();
+            foreach (var r in relations)
+            {
+                if (!maps.TryGetConcept(r.TargetType, out var concept))
+                    continue;
+                if (visited.Contains(r.TargetType))
+                    continue;
+
+                visited.Add(r.TargetType);
+                var relBlock = BuildRelationsBlock(ctx, r.TargetType, displayByFullName);
+                var nested = BuildLinkedConcepts(ctx, r.TargetType, displayByFullName, maps, visited, depth + 1);
+
+                list.Add(new UbiquitousLanguageConceptBlock
+                {
+                    Depth = depth,
+                    DisplayName = displayByFullName.TryGetValue(concept.FullName, out var d) ? d : concept.Name,
+                    KindLabel = phrases.KindLabelFor(concept.InternalKind),
+                    TypeName = concept.Name,
+                    FullName = concept.FullName,
+                    Description = string.IsNullOrWhiteSpace(concept.Description) ? null : concept.Description!.Trim(),
+                    Relations = relBlock,
+                    LinkedConcepts = nested,
+                });
+            }
+
+            return list;
+        }
+
+        private UbiquitousLanguageRelationsBlock BuildRelationsBlock(
+            BoundedContextNode ctx,
+            string sourceFullName,
+            Dictionary<string, string> displayByFullName)
+        {
+            var relations = ctx.Relationships
+                .Where(r =>
+                    string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
+                    StructuralOutgoingKinds.Contains(r.Kind))
+                .OrderBy(r => r.Kind)
+                .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
+                .Select(r => new UbiquitousLanguageRelationItem
+                {
+                    Kind = r.Kind,
+                    Phrase = phrases.RelationshipPhrase(r.Kind),
+                    TargetDisplayName = TargetDisplayOnly(r.TargetType, displayByFullName),
+                    TargetFullName = r.TargetType,
+                    ViaLabel = string.IsNullOrWhiteSpace(r.Label) ? null : r.Label,
                 })
                 .ToList();
-            eventsSection = new UbiquitousLanguageDomainEventsSection { Items = items };
+
+            return new UbiquitousLanguageRelationsBlock { Items = relations };
         }
 
-        return new UbiquitousLanguageBoundedContext
+        private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
         {
-            Name = ctx.Name,
-            Aggregates = aggregateSection,
-            DomainEvents = eventsSection,
-        };
-    }
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
 
-    private static UbiquitousLanguageConceptBlock BuildAggregateTree(
-        BoundedContextNode ctx,
-        AggregateNode aggregate,
-        Dictionary<string, string> displayByFullName,
-        TypeMaps maps)
-    {
-        var visited = new HashSet<string>(StringComparer.Ordinal) { aggregate.FullName };
-        var relations = BuildRelationsBlock(ctx, aggregate.FullName, displayByFullName);
-        var linked = BuildLinkedConcepts(ctx, aggregate.FullName, displayByFullName, maps, visited, depth: 1);
-
-        return new UbiquitousLanguageConceptBlock
-        {
-            Depth = 0,
-            DisplayName = DisplayName(aggregate),
-            KindLabel = "aggregate",
-            TypeName = aggregate.Name,
-            FullName = aggregate.FullName,
-            Description = string.IsNullOrWhiteSpace(aggregate.Description) ? null : aggregate.Description.Trim(),
-            Relations = relations,
-            LinkedConcepts = linked,
-        };
-    }
-
-    private static List<UbiquitousLanguageConceptBlock> BuildLinkedConcepts(
-        BoundedContextNode ctx,
-        string sourceFullName,
-        Dictionary<string, string> displayByFullName,
-        TypeMaps maps,
-        HashSet<string> visited,
-        int depth)
-    {
-        if (depth >= MaxConceptDepth)
-            return [];
-
-        var relations = ctx.Relationships
-            .Where(r =>
-                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
-                StructuralOutgoingKinds.Contains(r.Kind))
-            .OrderBy(r => r.Kind)
-            .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var list = new List<UbiquitousLanguageConceptBlock>();
-        foreach (var r in relations)
-        {
-            if (!maps.TryGetConcept(r.TargetType, out var concept))
-                continue;
-            if (visited.Contains(r.TargetType))
-                continue;
-
-            visited.Add(r.TargetType);
-            var relBlock = BuildRelationsBlock(ctx, r.TargetType, displayByFullName);
-            var nested = BuildLinkedConcepts(ctx, r.TargetType, displayByFullName, maps, visited, depth + 1);
-
-            list.Add(new UbiquitousLanguageConceptBlock
+            void Add(string fullName, string name, string? alias)
             {
-                Depth = depth,
-                DisplayName = displayByFullName.TryGetValue(concept.FullName, out var d) ? d : concept.Name,
-                KindLabel = concept.KindLabel,
-                TypeName = concept.Name,
-                FullName = concept.FullName,
-                Description = string.IsNullOrWhiteSpace(concept.Description) ? null : concept.Description!.Trim(),
-                Relations = relBlock,
-                LinkedConcepts = nested,
-            });
+                map[fullName] = string.IsNullOrWhiteSpace(alias) ? name : alias.Trim();
+            }
+
+            foreach (var n in ctx.Aggregates)
+                Add(n.FullName, n.Name, n.Alias);
+            foreach (var n in ctx.Entities)
+                Add(n.FullName, n.Name, n.Alias);
+            foreach (var n in ctx.ValueObjects)
+                Add(n.FullName, n.Name, n.Alias);
+            foreach (var n in ctx.DomainEvents)
+                Add(n.FullName, n.Name, n.Alias);
+            foreach (var n in ctx.IntegrationEvents)
+                Add(n.FullName, n.Name, n.Alias);
+            foreach (var n in ctx.SubTypes)
+                Add(n.FullName, n.Name, n.Alias);
+
+            return map;
         }
 
-        return list;
-    }
-
-    private static UbiquitousLanguageRelationsBlock BuildRelationsBlock(
-        BoundedContextNode ctx,
-        string sourceFullName,
-        Dictionary<string, string> displayByFullName)
-    {
-        var relations = ctx.Relationships
-            .Where(r =>
-                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
-                StructuralOutgoingKinds.Contains(r.Kind))
-            .OrderBy(r => r.Kind)
-            .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
-            .Select(r => new UbiquitousLanguageRelationItem
-            {
-                Kind = r.Kind,
-                Phrase = RelationshipPhrase(r.Kind),
-                TargetDisplayName = TargetDisplayOnly(r.TargetType, displayByFullName),
-                TargetFullName = r.TargetType,
-                ViaLabel = string.IsNullOrWhiteSpace(r.Label) ? null : r.Label,
-            })
-            .ToList();
-
-        return new UbiquitousLanguageRelationsBlock { Items = relations };
-    }
-
-    private static string RelationshipPhrase(RelationshipKind kind) => kind switch
-    {
-        RelationshipKind.Has => "has",
-        RelationshipKind.HasMany => "has many",
-        RelationshipKind.Contains => "contains",
-        RelationshipKind.References => "references",
-        RelationshipKind.ReferencesById => "references by id",
-        _ => kind.ToString().ToLowerInvariant(),
-    };
-
-    private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
-    {
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        void Add(string fullName, string name, string? alias)
+        private static string TargetDisplayOnly(string targetFullName, Dictionary<string, string> displayByFullName)
         {
-            map[fullName] = string.IsNullOrWhiteSpace(alias) ? name : alias.Trim();
+            if (displayByFullName.TryGetValue(targetFullName, out var label))
+                return label;
+            return targetFullName.Split('.').LastOrDefault() ?? targetFullName;
         }
 
-        foreach (var n in ctx.Aggregates)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.Entities)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.ValueObjects)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.DomainEvents)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.IntegrationEvents)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.SubTypes)
-            Add(n.FullName, n.Name, n.Alias);
+        private static string DisplayName(AggregateNode n) =>
+            string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
 
-        return map;
-    }
+        private static string DisplayName(DomainEventNode n) =>
+            string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
 
-    private static string TargetDisplayOnly(string targetFullName, Dictionary<string, string> displayByFullName)
-    {
-        if (displayByFullName.TryGetValue(targetFullName, out var label))
-            return label;
-        return targetFullName.Split('.').LastOrDefault() ?? targetFullName;
-    }
-
-    private static string DisplayName(AggregateNode n) =>
-        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
-
-    private static string DisplayName(DomainEventNode n) =>
-        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
-
-    private readonly struct DomainConcept(string fullName, string name, string? description, string kindLabel)
-    {
-        public string FullName { get; } = fullName;
-        public string Name { get; } = name;
-        public string? Description { get; } = description;
-        public string KindLabel { get; } = kindLabel;
-    }
-
-    private sealed class TypeMaps
-    {
-        private readonly Dictionary<string, AggregateNode> _aggregates;
-        private readonly Dictionary<string, EntityNode> _entities;
-        private readonly Dictionary<string, ValueObjectNode> _valueObjects;
-        private readonly Dictionary<string, SubTypeNode> _subTypes;
-
-        private TypeMaps(
-            Dictionary<string, AggregateNode> aggregates,
-            Dictionary<string, EntityNode> entities,
-            Dictionary<string, ValueObjectNode> valueObjects,
-            Dictionary<string, SubTypeNode> subTypes)
+        private readonly struct DomainConcept(string fullName, string name, string? description, string internalKind)
         {
-            _aggregates = aggregates;
-            _entities = entities;
-            _valueObjects = valueObjects;
-            _subTypes = subTypes;
+            public string FullName { get; } = fullName;
+            public string Name { get; } = name;
+            public string? Description { get; } = description;
+            public string InternalKind { get; } = internalKind;
         }
 
-        public static TypeMaps ForContext(BoundedContextNode ctx) => new(
-            ctx.Aggregates.ToDictionary(a => a.FullName, a => a, StringComparer.Ordinal),
-            ctx.Entities.ToDictionary(e => e.FullName, e => e, StringComparer.Ordinal),
-            ctx.ValueObjects.ToDictionary(v => v.FullName, v => v, StringComparer.Ordinal),
-            ctx.SubTypes.ToDictionary(s => s.FullName, s => s, StringComparer.Ordinal));
-
-        public bool TryGetConcept(string fullName, out DomainConcept concept)
+        private sealed class TypeMaps
         {
-            if (_aggregates.TryGetValue(fullName, out var a))
+            private readonly Dictionary<string, AggregateNode> _aggregates;
+            private readonly Dictionary<string, EntityNode> _entities;
+            private readonly Dictionary<string, ValueObjectNode> _valueObjects;
+            private readonly Dictionary<string, SubTypeNode> _subTypes;
+
+            private TypeMaps(
+                Dictionary<string, AggregateNode> aggregates,
+                Dictionary<string, EntityNode> entities,
+                Dictionary<string, ValueObjectNode> valueObjects,
+                Dictionary<string, SubTypeNode> subTypes)
             {
-                concept = new DomainConcept(a.FullName, a.Name, a.Description, "aggregate");
-                return true;
+                _aggregates = aggregates;
+                _entities = entities;
+                _valueObjects = valueObjects;
+                _subTypes = subTypes;
             }
 
-            if (_entities.TryGetValue(fullName, out var e))
-            {
-                concept = new DomainConcept(e.FullName, e.Name, e.Description, "entity");
-                return true;
-            }
+            public static TypeMaps ForContext(BoundedContextNode ctx) => new(
+                ctx.Aggregates.ToDictionary(a => a.FullName, a => a, StringComparer.Ordinal),
+                ctx.Entities.ToDictionary(e => e.FullName, e => e, StringComparer.Ordinal),
+                ctx.ValueObjects.ToDictionary(v => v.FullName, v => v, StringComparer.Ordinal),
+                ctx.SubTypes.ToDictionary(s => s.FullName, s => s, StringComparer.Ordinal));
 
-            if (_valueObjects.TryGetValue(fullName, out var v))
+            public bool TryGetConcept(string fullName, out DomainConcept concept)
             {
-                concept = new DomainConcept(v.FullName, v.Name, v.Description, "value object");
-                return true;
-            }
+                if (_aggregates.TryGetValue(fullName, out var a))
+                {
+                    concept = new DomainConcept(a.FullName, a.Name, a.Description, "aggregate");
+                    return true;
+                }
 
-            if (_subTypes.TryGetValue(fullName, out var s))
-            {
-                concept = new DomainConcept(s.FullName, s.Name, s.Description, "sub-type");
-                return true;
-            }
+                if (_entities.TryGetValue(fullName, out var e))
+                {
+                    concept = new DomainConcept(e.FullName, e.Name, e.Description, "entity");
+                    return true;
+                }
 
-            concept = default;
-            return false;
+                if (_valueObjects.TryGetValue(fullName, out var v))
+                {
+                    concept = new DomainConcept(v.FullName, v.Name, v.Description, "value object");
+                    return true;
+                }
+
+                if (_subTypes.TryGetValue(fullName, out var s))
+                {
+                    concept = new DomainConcept(s.FullName, s.Name, s.Description, "sub-type");
+                    return true;
+                }
+
+                concept = default;
+                return false;
+            }
         }
     }
 }

--- a/DomainModeling/Graph/UbiquitousLanguageDocument.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageDocument.cs
@@ -1,0 +1,364 @@
+namespace DomainModeling.Graph;
+
+/// <summary>
+/// Structured ubiquitous language view of a <see cref="DomainGraph"/> for UI or export.
+/// </summary>
+public sealed class UbiquitousLanguageDocument
+{
+    public required string Title { get; init; }
+    public string? Introduction { get; init; }
+    public List<UbiquitousLanguageBoundedContext> BoundedContexts { get; init; } = [];
+}
+
+public sealed class UbiquitousLanguageBoundedContext
+{
+    public required string Name { get; init; }
+    public UbiquitousLanguageAggregateSection Aggregates { get; init; } = new();
+    public UbiquitousLanguageDomainEventsSection DomainEvents { get; init; } = new();
+}
+
+public sealed class UbiquitousLanguageAggregateSection
+{
+    public string? EmptyMessage { get; init; }
+    public List<UbiquitousLanguageConceptBlock> Roots { get; init; } = [];
+}
+
+public sealed class UbiquitousLanguageDomainEventsSection
+{
+    public string? EmptyMessage { get; init; }
+    public List<UbiquitousLanguageDomainEventItem> Items { get; init; } = [];
+}
+
+/// <summary>
+/// An aggregate root and its nested linked concepts (entities, value objects, sub-types, nested aggregates).
+/// </summary>
+public sealed class UbiquitousLanguageConceptBlock
+{
+    /// <summary>Depth 0 = aggregate root; deeper values are nested concepts under the same aggregate tree.</summary>
+    public int Depth { get; init; }
+
+    public required string DisplayName { get; init; }
+    public required string KindLabel { get; init; }
+    public required string TypeName { get; init; }
+    public required string FullName { get; init; }
+    public string? Description { get; init; }
+    public UbiquitousLanguageRelationsBlock Relations { get; init; } = new();
+    public List<UbiquitousLanguageConceptBlock> LinkedConcepts { get; init; } = [];
+}
+
+public sealed class UbiquitousLanguageRelationsBlock
+{
+    public List<UbiquitousLanguageRelationItem> Items { get; init; } = [];
+}
+
+public sealed class UbiquitousLanguageRelationItem
+{
+    public required RelationshipKind Kind { get; init; }
+    public required string Phrase { get; init; }
+    public required string TargetDisplayName { get; init; }
+    public required string TargetFullName { get; init; }
+    public string? ViaLabel { get; init; }
+}
+
+public sealed class UbiquitousLanguageDomainEventItem
+{
+    public required string DisplayName { get; init; }
+    public required string TypeName { get; init; }
+    public required string FullName { get; init; }
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// Builds <see cref="UbiquitousLanguageDocument"/> from a domain graph (same rules as Markdown export).
+/// </summary>
+public static class UbiquitousLanguageDocumentBuilder
+{
+    private const int MaxConceptDepth = 4;
+
+    private static readonly HashSet<RelationshipKind> StructuralOutgoingKinds =
+    [
+        RelationshipKind.Has,
+        RelationshipKind.HasMany,
+        RelationshipKind.Contains,
+        RelationshipKind.References,
+        RelationshipKind.ReferencesById,
+    ];
+
+    /// <summary>
+    /// Produces a structured document for APIs and renderers.
+    /// </summary>
+    public static UbiquitousLanguageDocument Build(DomainGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var contexts = new List<UbiquitousLanguageBoundedContext>();
+        foreach (var ctx in graph.BoundedContexts)
+            contexts.Add(BuildBoundedContext(ctx));
+
+        return new UbiquitousLanguageDocument
+        {
+            Title = "Ubiquitous language",
+            Introduction =
+                "Generated from the domain model: aggregates with linked entities, value objects, and sub-types (structural relations, limited depth), then domain events — grouped by bounded context.",
+            BoundedContexts = contexts,
+        };
+    }
+
+    private static UbiquitousLanguageBoundedContext BuildBoundedContext(BoundedContextNode ctx)
+    {
+        UbiquitousLanguageAggregateSection aggregateSection;
+        if (ctx.Aggregates.Count == 0)
+        {
+            aggregateSection = new UbiquitousLanguageAggregateSection
+            {
+                EmptyMessage = "No aggregates in this bounded context.",
+            };
+        }
+        else
+        {
+            var displayByFullName = BuildDisplayLookup(ctx);
+            var typeMaps = TypeMaps.ForContext(ctx);
+            var roots = new List<UbiquitousLanguageConceptBlock>();
+            foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
+                roots.Add(BuildAggregateTree(ctx, aggregate, displayByFullName, typeMaps));
+
+            aggregateSection = new UbiquitousLanguageAggregateSection { Roots = roots };
+        }
+
+        UbiquitousLanguageDomainEventsSection eventsSection;
+        if (ctx.DomainEvents.Count == 0)
+        {
+            eventsSection = new UbiquitousLanguageDomainEventsSection
+            {
+                EmptyMessage = "No domain events in this bounded context.",
+            };
+        }
+        else
+        {
+            var items = ctx.DomainEvents
+                .OrderBy(e => DisplayName(e), StringComparer.OrdinalIgnoreCase)
+                .Select(e => new UbiquitousLanguageDomainEventItem
+                {
+                    DisplayName = DisplayName(e),
+                    TypeName = e.Name,
+                    FullName = e.FullName,
+                    Description = string.IsNullOrWhiteSpace(e.Description) ? null : e.Description.Trim(),
+                })
+                .ToList();
+            eventsSection = new UbiquitousLanguageDomainEventsSection { Items = items };
+        }
+
+        return new UbiquitousLanguageBoundedContext
+        {
+            Name = ctx.Name,
+            Aggregates = aggregateSection,
+            DomainEvents = eventsSection,
+        };
+    }
+
+    private static UbiquitousLanguageConceptBlock BuildAggregateTree(
+        BoundedContextNode ctx,
+        AggregateNode aggregate,
+        Dictionary<string, string> displayByFullName,
+        TypeMaps maps)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal) { aggregate.FullName };
+        var relations = BuildRelationsBlock(ctx, aggregate.FullName, displayByFullName);
+        var linked = BuildLinkedConcepts(ctx, aggregate.FullName, displayByFullName, maps, visited, depth: 1);
+
+        return new UbiquitousLanguageConceptBlock
+        {
+            Depth = 0,
+            DisplayName = DisplayName(aggregate),
+            KindLabel = "aggregate",
+            TypeName = aggregate.Name,
+            FullName = aggregate.FullName,
+            Description = string.IsNullOrWhiteSpace(aggregate.Description) ? null : aggregate.Description.Trim(),
+            Relations = relations,
+            LinkedConcepts = linked,
+        };
+    }
+
+    private static List<UbiquitousLanguageConceptBlock> BuildLinkedConcepts(
+        BoundedContextNode ctx,
+        string sourceFullName,
+        Dictionary<string, string> displayByFullName,
+        TypeMaps maps,
+        HashSet<string> visited,
+        int depth)
+    {
+        if (depth >= MaxConceptDepth)
+            return [];
+
+        var relations = ctx.Relationships
+            .Where(r =>
+                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
+                StructuralOutgoingKinds.Contains(r.Kind))
+            .OrderBy(r => r.Kind)
+            .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var list = new List<UbiquitousLanguageConceptBlock>();
+        foreach (var r in relations)
+        {
+            if (!maps.TryGetConcept(r.TargetType, out var concept))
+                continue;
+            if (visited.Contains(r.TargetType))
+                continue;
+
+            visited.Add(r.TargetType);
+            var relBlock = BuildRelationsBlock(ctx, r.TargetType, displayByFullName);
+            var nested = BuildLinkedConcepts(ctx, r.TargetType, displayByFullName, maps, visited, depth + 1);
+
+            list.Add(new UbiquitousLanguageConceptBlock
+            {
+                Depth = depth,
+                DisplayName = displayByFullName.TryGetValue(concept.FullName, out var d) ? d : concept.Name,
+                KindLabel = concept.KindLabel,
+                TypeName = concept.Name,
+                FullName = concept.FullName,
+                Description = string.IsNullOrWhiteSpace(concept.Description) ? null : concept.Description!.Trim(),
+                Relations = relBlock,
+                LinkedConcepts = nested,
+            });
+        }
+
+        return list;
+    }
+
+    private static UbiquitousLanguageRelationsBlock BuildRelationsBlock(
+        BoundedContextNode ctx,
+        string sourceFullName,
+        Dictionary<string, string> displayByFullName)
+    {
+        var relations = ctx.Relationships
+            .Where(r =>
+                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
+                StructuralOutgoingKinds.Contains(r.Kind))
+            .OrderBy(r => r.Kind)
+            .ThenBy(r => TargetDisplayOnly(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
+            .Select(r => new UbiquitousLanguageRelationItem
+            {
+                Kind = r.Kind,
+                Phrase = RelationshipPhrase(r.Kind),
+                TargetDisplayName = TargetDisplayOnly(r.TargetType, displayByFullName),
+                TargetFullName = r.TargetType,
+                ViaLabel = string.IsNullOrWhiteSpace(r.Label) ? null : r.Label,
+            })
+            .ToList();
+
+        return new UbiquitousLanguageRelationsBlock { Items = relations };
+    }
+
+    private static string RelationshipPhrase(RelationshipKind kind) => kind switch
+    {
+        RelationshipKind.Has => "has",
+        RelationshipKind.HasMany => "has many",
+        RelationshipKind.Contains => "contains",
+        RelationshipKind.References => "references",
+        RelationshipKind.ReferencesById => "references by id",
+        _ => kind.ToString().ToLowerInvariant(),
+    };
+
+    private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        void Add(string fullName, string name, string? alias)
+        {
+            map[fullName] = string.IsNullOrWhiteSpace(alias) ? name : alias.Trim();
+        }
+
+        foreach (var n in ctx.Aggregates)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.Entities)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.ValueObjects)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.DomainEvents)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.IntegrationEvents)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.SubTypes)
+            Add(n.FullName, n.Name, n.Alias);
+
+        return map;
+    }
+
+    private static string TargetDisplayOnly(string targetFullName, Dictionary<string, string> displayByFullName)
+    {
+        if (displayByFullName.TryGetValue(targetFullName, out var label))
+            return label;
+        return targetFullName.Split('.').LastOrDefault() ?? targetFullName;
+    }
+
+    private static string DisplayName(AggregateNode n) =>
+        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
+
+    private static string DisplayName(DomainEventNode n) =>
+        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
+
+    private readonly struct DomainConcept(string fullName, string name, string? description, string kindLabel)
+    {
+        public string FullName { get; } = fullName;
+        public string Name { get; } = name;
+        public string? Description { get; } = description;
+        public string KindLabel { get; } = kindLabel;
+    }
+
+    private sealed class TypeMaps
+    {
+        private readonly Dictionary<string, AggregateNode> _aggregates;
+        private readonly Dictionary<string, EntityNode> _entities;
+        private readonly Dictionary<string, ValueObjectNode> _valueObjects;
+        private readonly Dictionary<string, SubTypeNode> _subTypes;
+
+        private TypeMaps(
+            Dictionary<string, AggregateNode> aggregates,
+            Dictionary<string, EntityNode> entities,
+            Dictionary<string, ValueObjectNode> valueObjects,
+            Dictionary<string, SubTypeNode> subTypes)
+        {
+            _aggregates = aggregates;
+            _entities = entities;
+            _valueObjects = valueObjects;
+            _subTypes = subTypes;
+        }
+
+        public static TypeMaps ForContext(BoundedContextNode ctx) => new(
+            ctx.Aggregates.ToDictionary(a => a.FullName, a => a, StringComparer.Ordinal),
+            ctx.Entities.ToDictionary(e => e.FullName, e => e, StringComparer.Ordinal),
+            ctx.ValueObjects.ToDictionary(v => v.FullName, v => v, StringComparer.Ordinal),
+            ctx.SubTypes.ToDictionary(s => s.FullName, s => s, StringComparer.Ordinal));
+
+        public bool TryGetConcept(string fullName, out DomainConcept concept)
+        {
+            if (_aggregates.TryGetValue(fullName, out var a))
+            {
+                concept = new DomainConcept(a.FullName, a.Name, a.Description, "aggregate");
+                return true;
+            }
+
+            if (_entities.TryGetValue(fullName, out var e))
+            {
+                concept = new DomainConcept(e.FullName, e.Name, e.Description, "entity");
+                return true;
+            }
+
+            if (_valueObjects.TryGetValue(fullName, out var v))
+            {
+                concept = new DomainConcept(v.FullName, v.Name, v.Description, "value object");
+                return true;
+            }
+
+            if (_subTypes.TryGetValue(fullName, out var s))
+            {
+                concept = new DomainConcept(s.FullName, s.Name, s.Description, "sub-type");
+                return true;
+            }
+
+            concept = default;
+            return false;
+        }
+    }
+}

--- a/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
@@ -16,11 +16,21 @@ public static class UbiquitousLanguageMarkdownExport
     /// <summary>
     /// Creates Markdown with a custom definition and optional language key (<c>null</c> = definition default).
     /// </summary>
-    public static string Build(DomainGraph graph, UbiquitousLanguageDefinition definition, string? language = null)
+    public static string Build(DomainGraph graph, UbiquitousLanguageDefinition definition, string? language = null) =>
+        Build(graph, definition, language, boundedContextNames: null);
+
+    /// <summary>
+    /// Creates Markdown with optional bounded-context filter (same as <see cref="UbiquitousLanguageDocumentBuilder.Build"/>).
+    /// </summary>
+    public static string Build(
+        DomainGraph graph,
+        UbiquitousLanguageDefinition definition,
+        string? language,
+        IReadOnlyList<string>? boundedContextNames)
     {
         ArgumentNullException.ThrowIfNull(graph);
         ArgumentNullException.ThrowIfNull(definition);
-        return Build(UbiquitousLanguageDocumentBuilder.Build(graph, definition, language));
+        return Build(UbiquitousLanguageDocumentBuilder.Build(graph, definition, language, boundedContextNames));
     }
 
     /// <summary>

--- a/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
@@ -1,0 +1,167 @@
+using System.Text;
+
+namespace DomainModeling.Graph;
+
+/// <summary>
+/// Builds a Markdown document that summarizes the ubiquitous language for an entire <see cref="DomainGraph"/>:
+/// aggregates (with descriptions and <see cref="RelationshipKind.Has"/> / <see cref="RelationshipKind.HasMany"/>
+/// relations) and domain events (with descriptions), grouped by bounded context.
+/// </summary>
+public static class UbiquitousLanguageMarkdownExport
+{
+    /// <summary>
+    /// Creates Markdown suitable for download or documentation (e.g. registered via <c>AddExport</c> in ASP.NET Core).
+    /// </summary>
+    public static string Build(DomainGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Ubiquitous language");
+        sb.AppendLine();
+        sb.AppendLine("This document is generated from the domain model. It lists aggregates with their descriptions and structural relations, then domain events.");
+        sb.AppendLine();
+
+        foreach (var ctx in graph.BoundedContexts)
+        {
+            AppendBoundedContext(sb, ctx);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendBoundedContext(StringBuilder sb, BoundedContextNode ctx)
+    {
+        sb.AppendLine($"## Bounded context: {ctx.Name}");
+        sb.AppendLine();
+
+        sb.AppendLine("### Aggregates");
+        sb.AppendLine();
+
+        if (ctx.Aggregates.Count == 0)
+        {
+            sb.AppendLine("_No aggregates in this bounded context._");
+            sb.AppendLine();
+        }
+        else
+        {
+            var displayByFullName = BuildDisplayLookup(ctx);
+
+            foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
+            {
+                AppendAggregate(sb, ctx, aggregate, displayByFullName);
+            }
+        }
+
+        sb.AppendLine("### Domain events");
+        sb.AppendLine();
+
+        if (ctx.DomainEvents.Count == 0)
+        {
+            sb.AppendLine("_No domain events in this bounded context._");
+            sb.AppendLine();
+        }
+        else
+        {
+            foreach (var ev in ctx.DomainEvents.OrderBy(e => DisplayName(e), StringComparer.OrdinalIgnoreCase))
+            {
+                sb.AppendLine($"#### {DisplayName(ev)}");
+                sb.AppendLine();
+                if (!string.IsNullOrWhiteSpace(ev.Description))
+                {
+                    sb.AppendLine(ev.Description.Trim());
+                    sb.AppendLine();
+                }
+
+                sb.AppendLine($"_Type:_ `{ev.Name}`");
+                sb.AppendLine();
+            }
+        }
+    }
+
+    private static void AppendAggregate(
+        StringBuilder sb,
+        BoundedContextNode ctx,
+        AggregateNode aggregate,
+        Dictionary<string, string> displayByFullName)
+    {
+        sb.AppendLine($"#### {DisplayName(aggregate)}");
+        sb.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(aggregate.Description))
+        {
+            sb.AppendLine(aggregate.Description.Trim());
+            sb.AppendLine();
+        }
+
+        sb.AppendLine($"_Type:_ `{aggregate.Name}`");
+        sb.AppendLine();
+
+        var relations = ctx.Relationships
+            .Where(r =>
+                string.Equals(r.SourceType, aggregate.FullName, StringComparison.Ordinal) &&
+                (r.Kind == RelationshipKind.Has || r.Kind == RelationshipKind.HasMany))
+            .OrderBy(r => r.Kind)
+            .ThenBy(r => TargetLabel(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        sb.AppendLine("**Relations**");
+        sb.AppendLine();
+
+        if (relations.Count == 0)
+        {
+            sb.AppendLine("_No has / has many relations from this aggregate._");
+            sb.AppendLine();
+            return;
+        }
+
+        foreach (var r in relations)
+        {
+            var phrase = r.Kind == RelationshipKind.HasMany ? "has many" : "has";
+            var target = TargetLabel(r.TargetType, displayByFullName);
+            sb.AppendLine($"- **{phrase}** {target}");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        void Add(string fullName, string name, string? alias)
+        {
+            map[fullName] = string.IsNullOrWhiteSpace(alias) ? name : alias.Trim();
+        }
+
+        foreach (var n in ctx.Aggregates)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.Entities)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.ValueObjects)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.DomainEvents)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.IntegrationEvents)
+            Add(n.FullName, n.Name, n.Alias);
+        foreach (var n in ctx.SubTypes)
+            Add(n.FullName, n.Name, n.Alias);
+
+        return map;
+    }
+
+    private static string TargetLabel(string targetFullName, Dictionary<string, string> displayByFullName)
+    {
+        if (displayByFullName.TryGetValue(targetFullName, out var label))
+            return $"`{label}`";
+
+        var shortName = targetFullName.Split('.').LastOrDefault() ?? targetFullName;
+        return $"`{shortName}`";
+    }
+
+    private static string DisplayName(AggregateNode n) =>
+        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
+
+    private static string DisplayName(DomainEventNode n) =>
+        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
+}

--- a/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
@@ -3,44 +3,42 @@ using System.Text;
 namespace DomainModeling.Graph;
 
 /// <summary>
-/// Builds a Markdown document that summarizes the ubiquitous language for an entire <see cref="DomainGraph"/>:
-/// bounded contexts with aggregates (descriptions and structural relations), recursively linked entities,
-/// value objects, and sub-types up to a fixed depth, then domain events.
+/// Renders <see cref="UbiquitousLanguageDocument"/> as Markdown (same content as <see cref="UbiquitousLanguageDocumentBuilder"/>).
 /// </summary>
 public static class UbiquitousLanguageMarkdownExport
 {
-    /// <summary>Maximum number of hops from an aggregate root into linked domain concepts (entities, value objects, sub-types, other aggregates).</summary>
-    private const int MaxConceptDepth = 4;
-
-    private static readonly HashSet<RelationshipKind> StructuralOutgoingKinds =
-    [
-        RelationshipKind.Has,
-        RelationshipKind.HasMany,
-        RelationshipKind.Contains,
-        RelationshipKind.References,
-        RelationshipKind.ReferencesById,
-    ];
-
     /// <summary>
     /// Creates Markdown suitable for download or documentation (e.g. registered via <c>AddExport</c> in ASP.NET Core).
     /// </summary>
     public static string Build(DomainGraph graph)
     {
         ArgumentNullException.ThrowIfNull(graph);
+        return Build(UbiquitousLanguageDocumentBuilder.Build(graph));
+    }
+
+    /// <summary>
+    /// Renders a pre-built ubiquitous language document as Markdown.
+    /// </summary>
+    public static string Build(UbiquitousLanguageDocument doc)
+    {
+        ArgumentNullException.ThrowIfNull(doc);
 
         var sb = new StringBuilder();
-        sb.AppendLine("# Ubiquitous language");
+        sb.AppendLine($"# {doc.Title}");
         sb.AppendLine();
-        sb.AppendLine("This document is generated from the domain model. It is grouped by bounded context: aggregates with linked entities, value objects, and sub-types (structural relations, limited depth), then domain events.");
-        sb.AppendLine();
+        if (!string.IsNullOrWhiteSpace(doc.Introduction))
+        {
+            sb.AppendLine(doc.Introduction.Trim());
+            sb.AppendLine();
+        }
 
-        foreach (var ctx in graph.BoundedContexts)
+        foreach (var ctx in doc.BoundedContexts)
             AppendBoundedContext(sb, ctx);
 
         return sb.ToString();
     }
 
-    private static void AppendBoundedContext(StringBuilder sb, BoundedContextNode ctx)
+    private static void AppendBoundedContext(StringBuilder sb, UbiquitousLanguageBoundedContext ctx)
     {
         sb.AppendLine($"## Bounded context: {ctx.Name}");
         sb.AppendLine();
@@ -48,33 +46,30 @@ public static class UbiquitousLanguageMarkdownExport
         sb.AppendLine("### Aggregates");
         sb.AppendLine();
 
-        if (ctx.Aggregates.Count == 0)
+        if (!string.IsNullOrEmpty(ctx.Aggregates.EmptyMessage))
         {
-            sb.AppendLine("_No aggregates in this bounded context._");
+            sb.AppendLine($"_{ctx.Aggregates.EmptyMessage}_");
             sb.AppendLine();
         }
         else
         {
-            var displayByFullName = BuildDisplayLookup(ctx);
-            var typeMaps = TypeMaps.ForContext(ctx);
-
-            foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
-                AppendAggregateWithLinkedConcepts(sb, ctx, aggregate, displayByFullName, typeMaps);
+            foreach (var root in ctx.Aggregates.Roots)
+                AppendConceptTree(sb, root, indent: "");
         }
 
         sb.AppendLine("### Domain events");
         sb.AppendLine();
 
-        if (ctx.DomainEvents.Count == 0)
+        if (!string.IsNullOrEmpty(ctx.DomainEvents.EmptyMessage))
         {
-            sb.AppendLine("_No domain events in this bounded context._");
+            sb.AppendLine($"_{ctx.DomainEvents.EmptyMessage}_");
             sb.AppendLine();
         }
         else
         {
-            foreach (var ev in ctx.DomainEvents.OrderBy(e => DisplayName(e), StringComparer.OrdinalIgnoreCase))
+            foreach (var ev in ctx.DomainEvents.Items)
             {
-                sb.AppendLine($"#### {DisplayName(ev)}");
+                sb.AppendLine($"#### {ev.DisplayName}");
                 sb.AppendLine();
                 if (!string.IsNullOrWhiteSpace(ev.Description))
                 {
@@ -82,246 +77,65 @@ public static class UbiquitousLanguageMarkdownExport
                     sb.AppendLine();
                 }
 
-                sb.AppendLine($"_Type:_ `{ev.Name}`");
+                sb.AppendLine($"_Type:_ `{ev.TypeName}`");
                 sb.AppendLine();
             }
         }
     }
 
-    private static void AppendAggregateWithLinkedConcepts(
-        StringBuilder sb,
-        BoundedContextNode ctx,
-        AggregateNode aggregate,
-        Dictionary<string, string> displayByFullName,
-        TypeMaps maps)
+    /// <summary>
+    /// Aggregate roots use <c>####</c> headings; nested linked concepts use indented bold lines (max 4 heading levels in the file).
+    /// </summary>
+    private static void AppendConceptTree(StringBuilder sb, UbiquitousLanguageConceptBlock block, string indent)
     {
-        sb.AppendLine($"#### {DisplayName(aggregate)}");
-        sb.AppendLine();
-
-        if (!string.IsNullOrWhiteSpace(aggregate.Description))
+        if (block.Depth == 0)
         {
-            sb.AppendLine(aggregate.Description.Trim());
-            sb.AppendLine();
-        }
-
-        sb.AppendLine($"_Type:_ `{aggregate.Name}`");
-        sb.AppendLine();
-
-        var visited = new HashSet<string>(StringComparer.Ordinal) { aggregate.FullName };
-        AppendRelationsAndLinkedConcepts(
-            sb,
-            ctx,
-            aggregate.FullName,
-            displayByFullName,
-            maps,
-            visited,
-            depth: 1,
-            indent: "");
-    }
-
-    private static void AppendRelationsAndLinkedConcepts(
-        StringBuilder sb,
-        BoundedContextNode ctx,
-        string sourceFullName,
-        Dictionary<string, string> displayByFullName,
-        TypeMaps maps,
-        HashSet<string> visited,
-        int depth,
-        string indent)
-    {
-        if (depth > MaxConceptDepth)
-            return;
-
-        var relations = ctx.Relationships
-            .Where(r =>
-                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
-                StructuralOutgoingKinds.Contains(r.Kind))
-            .OrderBy(r => r.Kind)
-            .ThenBy(r => TargetLabel(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        sb.AppendLine($"{indent}**Relations**");
-        sb.AppendLine();
-
-        if (relations.Count == 0)
-        {
-            sb.AppendLine($"{indent}_None from this concept._");
+            sb.AppendLine($"#### {block.DisplayName}");
             sb.AppendLine();
         }
         else
         {
-            foreach (var r in relations)
-            {
-                var phrase = RelationshipPhrase(r.Kind);
-                var target = TargetLabel(r.TargetType, displayByFullName);
-                var via = string.IsNullOrWhiteSpace(r.Label) ? "" : $" _(via `{r.Label}`)_";
-                sb.AppendLine($"{indent}- **{phrase}** {target}{via}");
-            }
-
+            sb.AppendLine($"{indent}**{block.DisplayName}** _({block.KindLabel})_");
             sb.AppendLine();
         }
 
-        var childIndent = indent + "  ";
-        if (depth >= MaxConceptDepth)
-            return;
-
-        foreach (var r in relations)
+        if (!string.IsNullOrWhiteSpace(block.Description))
         {
-            if (!maps.TryGetConcept(r.TargetType, out var concept))
-                continue;
-
-            if (visited.Contains(r.TargetType))
-                continue;
-
-            visited.Add(r.TargetType);
-            AppendConceptBlock(sb, concept, displayByFullName, childIndent);
-            AppendRelationsAndLinkedConcepts(
-                sb,
-                ctx,
-                r.TargetType,
-                displayByFullName,
-                maps,
-                visited,
-                depth + 1,
-                childIndent);
-        }
-    }
-
-    private static void AppendConceptBlock(
-        StringBuilder sb,
-        DomainConcept concept,
-        Dictionary<string, string> displayByFullName,
-        string indent)
-    {
-        var display = displayByFullName.TryGetValue(concept.FullName, out var d) ? d : concept.Name;
-        var kindLabel = concept.KindLabel;
-
-        sb.AppendLine($"{indent}**{display}** _({kindLabel})_");
-        sb.AppendLine();
-
-        if (!string.IsNullOrWhiteSpace(concept.Description))
-        {
-            foreach (var line in concept.Description!.Trim().Split('\n'))
+            foreach (var line in block.Description!.Trim().Split('\n'))
                 sb.AppendLine($"{indent}{line.TrimEnd()}");
 
             sb.AppendLine();
         }
 
-        sb.AppendLine($"{indent}_Type:_ `{concept.Name}`");
+        sb.AppendLine($"{indent}_Type:_ `{block.TypeName}`");
         sb.AppendLine();
+
+        AppendRelationsMarkdown(sb, block.Relations, indent);
+
+        var childIndent = indent + "  ";
+        foreach (var child in block.LinkedConcepts)
+            AppendConceptTree(sb, child, childIndent);
     }
 
-    private static string RelationshipPhrase(RelationshipKind kind) => kind switch
+    private static void AppendRelationsMarkdown(StringBuilder sb, UbiquitousLanguageRelationsBlock rel, string indent)
     {
-        RelationshipKind.Has => "has",
-        RelationshipKind.HasMany => "has many",
-        RelationshipKind.Contains => "contains",
-        RelationshipKind.References => "references",
-        RelationshipKind.ReferencesById => "references by id",
-        _ => kind.ToString().ToLowerInvariant(),
-    };
+        sb.AppendLine($"{indent}**Relations**");
+        sb.AppendLine();
 
-    private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
-    {
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        void Add(string fullName, string name, string? alias)
+        if (rel.Items.Count == 0)
         {
-            map[fullName] = string.IsNullOrWhiteSpace(alias) ? name : alias.Trim();
+            sb.AppendLine($"{indent}_None from this concept._");
+            sb.AppendLine();
+            return;
         }
 
-        foreach (var n in ctx.Aggregates)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.Entities)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.ValueObjects)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.DomainEvents)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.IntegrationEvents)
-            Add(n.FullName, n.Name, n.Alias);
-        foreach (var n in ctx.SubTypes)
-            Add(n.FullName, n.Name, n.Alias);
-
-        return map;
-    }
-
-    private static string TargetLabel(string targetFullName, Dictionary<string, string> displayByFullName)
-    {
-        if (displayByFullName.TryGetValue(targetFullName, out var label))
-            return $"`{label}`";
-
-        var shortName = targetFullName.Split('.').LastOrDefault() ?? targetFullName;
-        return $"`{shortName}`";
-    }
-
-    private static string DisplayName(AggregateNode n) =>
-        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
-
-    private static string DisplayName(DomainEventNode n) =>
-        string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
-
-    private readonly struct DomainConcept(string fullName, string name, string? description, string kindLabel)
-    {
-        public string FullName { get; } = fullName;
-        public string Name { get; } = name;
-        public string? Description { get; } = description;
-        public string KindLabel { get; } = kindLabel;
-    }
-
-    private sealed class TypeMaps
-    {
-        private readonly Dictionary<string, AggregateNode> _aggregates;
-        private readonly Dictionary<string, EntityNode> _entities;
-        private readonly Dictionary<string, ValueObjectNode> _valueObjects;
-        private readonly Dictionary<string, SubTypeNode> _subTypes;
-
-        private TypeMaps(
-            Dictionary<string, AggregateNode> aggregates,
-            Dictionary<string, EntityNode> entities,
-            Dictionary<string, ValueObjectNode> valueObjects,
-            Dictionary<string, SubTypeNode> subTypes)
+        foreach (var r in rel.Items)
         {
-            _aggregates = aggregates;
-            _entities = entities;
-            _valueObjects = valueObjects;
-            _subTypes = subTypes;
+            var target = $"`{r.TargetDisplayName}`";
+            var via = string.IsNullOrWhiteSpace(r.ViaLabel) ? "" : $" _(via `{r.ViaLabel}`)_";
+            sb.AppendLine($"{indent}- **{r.Phrase}** {target}{via}");
         }
 
-        public static TypeMaps ForContext(BoundedContextNode ctx) => new(
-            ctx.Aggregates.ToDictionary(a => a.FullName, a => a, StringComparer.Ordinal),
-            ctx.Entities.ToDictionary(e => e.FullName, e => e, StringComparer.Ordinal),
-            ctx.ValueObjects.ToDictionary(v => v.FullName, v => v, StringComparer.Ordinal),
-            ctx.SubTypes.ToDictionary(s => s.FullName, s => s, StringComparer.Ordinal));
-
-        public bool TryGetConcept(string fullName, out DomainConcept concept)
-        {
-            if (_aggregates.TryGetValue(fullName, out var a))
-            {
-                concept = new DomainConcept(a.FullName, a.Name, a.Description, "aggregate");
-                return true;
-            }
-
-            if (_entities.TryGetValue(fullName, out var e))
-            {
-                concept = new DomainConcept(e.FullName, e.Name, e.Description, "entity");
-                return true;
-            }
-
-            if (_valueObjects.TryGetValue(fullName, out var v))
-            {
-                concept = new DomainConcept(v.FullName, v.Name, v.Description, "value object");
-                return true;
-            }
-
-            if (_subTypes.TryGetValue(fullName, out var s))
-            {
-                concept = new DomainConcept(s.FullName, s.Name, s.Description, "sub-type");
-                return true;
-            }
-
-            concept = default;
-            return false;
-        }
+        sb.AppendLine();
     }
 }

--- a/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
@@ -8,12 +8,19 @@ namespace DomainModeling.Graph;
 public static class UbiquitousLanguageMarkdownExport
 {
     /// <summary>
-    /// Creates Markdown suitable for download or documentation (e.g. registered via <c>AddExport</c> in ASP.NET Core).
+    /// Creates Markdown using the default English ubiquitous language definition.
     /// </summary>
-    public static string Build(DomainGraph graph)
+    public static string Build(DomainGraph graph) =>
+        Build(UbiquitousLanguageDocumentBuilder.Build(graph));
+
+    /// <summary>
+    /// Creates Markdown with a custom definition and optional language key (<c>null</c> = definition default).
+    /// </summary>
+    public static string Build(DomainGraph graph, UbiquitousLanguageDefinition definition, string? language = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        return Build(UbiquitousLanguageDocumentBuilder.Build(graph));
+        ArgumentNullException.ThrowIfNull(definition);
+        return Build(UbiquitousLanguageDocumentBuilder.Build(graph, definition, language));
     }
 
     /// <summary>
@@ -33,17 +40,22 @@ public static class UbiquitousLanguageMarkdownExport
         }
 
         foreach (var ctx in doc.BoundedContexts)
-            AppendBoundedContext(sb, ctx);
+            AppendBoundedContext(sb, ctx, doc);
 
         return sb.ToString();
     }
 
-    private static void AppendBoundedContext(StringBuilder sb, UbiquitousLanguageBoundedContext ctx)
+    private static void AppendBoundedContext(StringBuilder sb, UbiquitousLanguageBoundedContext ctx, UbiquitousLanguageDocument doc)
     {
-        sb.AppendLine($"## Bounded context: {ctx.Name}");
+        var bcHeading = string.Format(doc.BoundedContextMarkdownHeadingFormat, ctx.Name);
+        if (!bcHeading.StartsWith('#'))
+            sb.AppendLine($"## {bcHeading}");
+        else
+            sb.AppendLine(bcHeading);
+
         sb.AppendLine();
 
-        sb.AppendLine("### Aggregates");
+        sb.AppendLine($"### {doc.AggregatesSectionLabel}");
         sb.AppendLine();
 
         if (!string.IsNullOrEmpty(ctx.Aggregates.EmptyMessage))
@@ -54,10 +66,10 @@ public static class UbiquitousLanguageMarkdownExport
         else
         {
             foreach (var root in ctx.Aggregates.Roots)
-                AppendConceptTree(sb, root, indent: "");
+                AppendConceptTree(sb, root, doc, indent: "");
         }
 
-        sb.AppendLine("### Domain events");
+        sb.AppendLine($"### {doc.DomainEventsSectionLabel}");
         sb.AppendLine();
 
         if (!string.IsNullOrEmpty(ctx.DomainEvents.EmptyMessage))
@@ -77,16 +89,13 @@ public static class UbiquitousLanguageMarkdownExport
                     sb.AppendLine();
                 }
 
-                sb.AppendLine($"_Type:_ `{ev.TypeName}`");
+                sb.AppendLine($"_{doc.TypeLabelPrefix}:_ `{ev.TypeName}`");
                 sb.AppendLine();
             }
         }
     }
 
-    /// <summary>
-    /// Aggregate roots use <c>####</c> headings; nested linked concepts use indented bold lines (max 4 heading levels in the file).
-    /// </summary>
-    private static void AppendConceptTree(StringBuilder sb, UbiquitousLanguageConceptBlock block, string indent)
+    private static void AppendConceptTree(StringBuilder sb, UbiquitousLanguageConceptBlock block, UbiquitousLanguageDocument doc, string indent)
     {
         if (block.Depth == 0)
         {
@@ -107,24 +116,28 @@ public static class UbiquitousLanguageMarkdownExport
             sb.AppendLine();
         }
 
-        sb.AppendLine($"{indent}_Type:_ `{block.TypeName}`");
+        sb.AppendLine($"{indent}_{doc.TypeLabelPrefix}:_ `{block.TypeName}`");
         sb.AppendLine();
 
-        AppendRelationsMarkdown(sb, block.Relations, indent);
+        AppendRelationsMarkdown(sb, block.Relations, doc, indent);
 
         var childIndent = indent + "  ";
         foreach (var child in block.LinkedConcepts)
-            AppendConceptTree(sb, child, childIndent);
+            AppendConceptTree(sb, child, doc, childIndent);
     }
 
-    private static void AppendRelationsMarkdown(StringBuilder sb, UbiquitousLanguageRelationsBlock rel, string indent)
+    private static void AppendRelationsMarkdown(
+        StringBuilder sb,
+        UbiquitousLanguageRelationsBlock rel,
+        UbiquitousLanguageDocument doc,
+        string indent)
     {
-        sb.AppendLine($"{indent}**Relations**");
+        sb.AppendLine($"{indent}**{doc.RelationsHeadingLabel}**");
         sb.AppendLine();
 
         if (rel.Items.Count == 0)
         {
-            sb.AppendLine($"{indent}_None from this concept._");
+            sb.AppendLine($"{indent}_{doc.NoRelationsMessage}_");
             sb.AppendLine();
             return;
         }
@@ -132,7 +145,9 @@ public static class UbiquitousLanguageMarkdownExport
         foreach (var r in rel.Items)
         {
             var target = $"`{r.TargetDisplayName}`";
-            var via = string.IsNullOrWhiteSpace(r.ViaLabel) ? "" : $" _(via `{r.ViaLabel}`)_";
+            var via = string.IsNullOrWhiteSpace(r.ViaLabel)
+                ? ""
+                : $" _({doc.RelationshipViaWord} `{r.ViaLabel}`)_";
             sb.AppendLine($"{indent}- **{r.Phrase}** {target}{via}");
         }
 

--- a/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
+++ b/DomainModeling/Graph/UbiquitousLanguageMarkdownExport.cs
@@ -4,11 +4,23 @@ namespace DomainModeling.Graph;
 
 /// <summary>
 /// Builds a Markdown document that summarizes the ubiquitous language for an entire <see cref="DomainGraph"/>:
-/// aggregates (with descriptions and <see cref="RelationshipKind.Has"/> / <see cref="RelationshipKind.HasMany"/>
-/// relations) and domain events (with descriptions), grouped by bounded context.
+/// bounded contexts with aggregates (descriptions and structural relations), recursively linked entities,
+/// value objects, and sub-types up to a fixed depth, then domain events.
 /// </summary>
 public static class UbiquitousLanguageMarkdownExport
 {
+    /// <summary>Maximum number of hops from an aggregate root into linked domain concepts (entities, value objects, sub-types, other aggregates).</summary>
+    private const int MaxConceptDepth = 4;
+
+    private static readonly HashSet<RelationshipKind> StructuralOutgoingKinds =
+    [
+        RelationshipKind.Has,
+        RelationshipKind.HasMany,
+        RelationshipKind.Contains,
+        RelationshipKind.References,
+        RelationshipKind.ReferencesById,
+    ];
+
     /// <summary>
     /// Creates Markdown suitable for download or documentation (e.g. registered via <c>AddExport</c> in ASP.NET Core).
     /// </summary>
@@ -19,13 +31,11 @@ public static class UbiquitousLanguageMarkdownExport
         var sb = new StringBuilder();
         sb.AppendLine("# Ubiquitous language");
         sb.AppendLine();
-        sb.AppendLine("This document is generated from the domain model. It lists aggregates with their descriptions and structural relations, then domain events.");
+        sb.AppendLine("This document is generated from the domain model. It is grouped by bounded context: aggregates with linked entities, value objects, and sub-types (structural relations, limited depth), then domain events.");
         sb.AppendLine();
 
         foreach (var ctx in graph.BoundedContexts)
-        {
             AppendBoundedContext(sb, ctx);
-        }
 
         return sb.ToString();
     }
@@ -46,11 +56,10 @@ public static class UbiquitousLanguageMarkdownExport
         else
         {
             var displayByFullName = BuildDisplayLookup(ctx);
+            var typeMaps = TypeMaps.ForContext(ctx);
 
             foreach (var aggregate in ctx.Aggregates.OrderBy(a => DisplayName(a), StringComparer.OrdinalIgnoreCase))
-            {
-                AppendAggregate(sb, ctx, aggregate, displayByFullName);
-            }
+                AppendAggregateWithLinkedConcepts(sb, ctx, aggregate, displayByFullName, typeMaps);
         }
 
         sb.AppendLine("### Domain events");
@@ -79,11 +88,12 @@ public static class UbiquitousLanguageMarkdownExport
         }
     }
 
-    private static void AppendAggregate(
+    private static void AppendAggregateWithLinkedConcepts(
         StringBuilder sb,
         BoundedContextNode ctx,
         AggregateNode aggregate,
-        Dictionary<string, string> displayByFullName)
+        Dictionary<string, string> displayByFullName,
+        TypeMaps maps)
     {
         sb.AppendLine($"#### {DisplayName(aggregate)}");
         sb.AppendLine();
@@ -97,33 +107,119 @@ public static class UbiquitousLanguageMarkdownExport
         sb.AppendLine($"_Type:_ `{aggregate.Name}`");
         sb.AppendLine();
 
+        var visited = new HashSet<string>(StringComparer.Ordinal) { aggregate.FullName };
+        AppendRelationsAndLinkedConcepts(
+            sb,
+            ctx,
+            aggregate.FullName,
+            displayByFullName,
+            maps,
+            visited,
+            depth: 1,
+            indent: "");
+    }
+
+    private static void AppendRelationsAndLinkedConcepts(
+        StringBuilder sb,
+        BoundedContextNode ctx,
+        string sourceFullName,
+        Dictionary<string, string> displayByFullName,
+        TypeMaps maps,
+        HashSet<string> visited,
+        int depth,
+        string indent)
+    {
+        if (depth > MaxConceptDepth)
+            return;
+
         var relations = ctx.Relationships
             .Where(r =>
-                string.Equals(r.SourceType, aggregate.FullName, StringComparison.Ordinal) &&
-                (r.Kind == RelationshipKind.Has || r.Kind == RelationshipKind.HasMany))
+                string.Equals(r.SourceType, sourceFullName, StringComparison.Ordinal) &&
+                StructuralOutgoingKinds.Contains(r.Kind))
             .OrderBy(r => r.Kind)
             .ThenBy(r => TargetLabel(r.TargetType, displayByFullName), StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        sb.AppendLine("**Relations**");
+        sb.AppendLine($"{indent}**Relations**");
         sb.AppendLine();
 
         if (relations.Count == 0)
         {
-            sb.AppendLine("_No has / has many relations from this aggregate._");
+            sb.AppendLine($"{indent}_None from this concept._");
             sb.AppendLine();
-            return;
         }
+        else
+        {
+            foreach (var r in relations)
+            {
+                var phrase = RelationshipPhrase(r.Kind);
+                var target = TargetLabel(r.TargetType, displayByFullName);
+                var via = string.IsNullOrWhiteSpace(r.Label) ? "" : $" _(via `{r.Label}`)_";
+                sb.AppendLine($"{indent}- **{phrase}** {target}{via}");
+            }
+
+            sb.AppendLine();
+        }
+
+        var childIndent = indent + "  ";
+        if (depth >= MaxConceptDepth)
+            return;
 
         foreach (var r in relations)
         {
-            var phrase = r.Kind == RelationshipKind.HasMany ? "has many" : "has";
-            var target = TargetLabel(r.TargetType, displayByFullName);
-            sb.AppendLine($"- **{phrase}** {target}");
+            if (!maps.TryGetConcept(r.TargetType, out var concept))
+                continue;
+
+            if (visited.Contains(r.TargetType))
+                continue;
+
+            visited.Add(r.TargetType);
+            AppendConceptBlock(sb, concept, displayByFullName, childIndent);
+            AppendRelationsAndLinkedConcepts(
+                sb,
+                ctx,
+                r.TargetType,
+                displayByFullName,
+                maps,
+                visited,
+                depth + 1,
+                childIndent);
+        }
+    }
+
+    private static void AppendConceptBlock(
+        StringBuilder sb,
+        DomainConcept concept,
+        Dictionary<string, string> displayByFullName,
+        string indent)
+    {
+        var display = displayByFullName.TryGetValue(concept.FullName, out var d) ? d : concept.Name;
+        var kindLabel = concept.KindLabel;
+
+        sb.AppendLine($"{indent}**{display}** _({kindLabel})_");
+        sb.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(concept.Description))
+        {
+            foreach (var line in concept.Description!.Trim().Split('\n'))
+                sb.AppendLine($"{indent}{line.TrimEnd()}");
+
+            sb.AppendLine();
         }
 
+        sb.AppendLine($"{indent}_Type:_ `{concept.Name}`");
         sb.AppendLine();
     }
+
+    private static string RelationshipPhrase(RelationshipKind kind) => kind switch
+    {
+        RelationshipKind.Has => "has",
+        RelationshipKind.HasMany => "has many",
+        RelationshipKind.Contains => "contains",
+        RelationshipKind.References => "references",
+        RelationshipKind.ReferencesById => "references by id",
+        _ => kind.ToString().ToLowerInvariant(),
+    };
 
     private static Dictionary<string, string> BuildDisplayLookup(BoundedContextNode ctx)
     {
@@ -164,4 +260,68 @@ public static class UbiquitousLanguageMarkdownExport
 
     private static string DisplayName(DomainEventNode n) =>
         string.IsNullOrWhiteSpace(n.Alias) ? n.Name : n.Alias.Trim();
+
+    private readonly struct DomainConcept(string fullName, string name, string? description, string kindLabel)
+    {
+        public string FullName { get; } = fullName;
+        public string Name { get; } = name;
+        public string? Description { get; } = description;
+        public string KindLabel { get; } = kindLabel;
+    }
+
+    private sealed class TypeMaps
+    {
+        private readonly Dictionary<string, AggregateNode> _aggregates;
+        private readonly Dictionary<string, EntityNode> _entities;
+        private readonly Dictionary<string, ValueObjectNode> _valueObjects;
+        private readonly Dictionary<string, SubTypeNode> _subTypes;
+
+        private TypeMaps(
+            Dictionary<string, AggregateNode> aggregates,
+            Dictionary<string, EntityNode> entities,
+            Dictionary<string, ValueObjectNode> valueObjects,
+            Dictionary<string, SubTypeNode> subTypes)
+        {
+            _aggregates = aggregates;
+            _entities = entities;
+            _valueObjects = valueObjects;
+            _subTypes = subTypes;
+        }
+
+        public static TypeMaps ForContext(BoundedContextNode ctx) => new(
+            ctx.Aggregates.ToDictionary(a => a.FullName, a => a, StringComparer.Ordinal),
+            ctx.Entities.ToDictionary(e => e.FullName, e => e, StringComparer.Ordinal),
+            ctx.ValueObjects.ToDictionary(v => v.FullName, v => v, StringComparer.Ordinal),
+            ctx.SubTypes.ToDictionary(s => s.FullName, s => s, StringComparer.Ordinal));
+
+        public bool TryGetConcept(string fullName, out DomainConcept concept)
+        {
+            if (_aggregates.TryGetValue(fullName, out var a))
+            {
+                concept = new DomainConcept(a.FullName, a.Name, a.Description, "aggregate");
+                return true;
+            }
+
+            if (_entities.TryGetValue(fullName, out var e))
+            {
+                concept = new DomainConcept(e.FullName, e.Name, e.Description, "entity");
+                return true;
+            }
+
+            if (_valueObjects.TryGetValue(fullName, out var v))
+            {
+                concept = new DomainConcept(v.FullName, v.Name, v.Description, "value object");
+                return true;
+            }
+
+            if (_subTypes.TryGetValue(fullName, out var s))
+            {
+                concept = new DomainConcept(s.FullName, s.Name, s.Description, "sub-type");
+                return true;
+            }
+
+            concept = default;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ubiquitous language: Language tab, Markdown download, pluggable definitions, **bounded context picker** at top of page, shared server pipeline.

## Bounded context selection

- **UI:** Top toolbar — **Bounded context** dropdown when the model has 2+ contexts (`All bounded contexts` or one name). Choice stored in `localStorage` (`domainModelUbiquitousLanguageBc`). With **All** selected, the sidebar’s multi-select still filters which contexts appear (unchanged). With a **single** context chosen in the dropdown, that context is shown regardless of sidebar checkboxes for this tab only.
- **API:** `GET …/ubiquitous-language?context=Catalog` (repeatable or comma-separated) and same on `…/ubiquitous-language.md`. JSON includes `filteredToBoundedContexts` when a filter is applied.
- **Builder:** `UbiquitousLanguageDocumentBuilder.Build(..., boundedContextNames)`; Markdown uses the same overload.

Related: #63
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4ad520e-5aca-4edb-915e-c35ca2b57a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4ad520e-5aca-4edb-915e-c35ca2b57a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

