### PR TITLE
Relationship link metadata: edit, hide, describe (diagram + feature editor)

### DIFF
--- a/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
+++ b/DomainModeling.AspNetCore/DomainModelEndpointExtensions.cs
@@ -205,11 +205,18 @@ public static class DomainModelEndpointExtensions
         // Custom metadata store (alias / description per type) persisted as JSON files on disk
         var metadataDir = Path.GetFullPath(options.MetadataStoragePath);
         var metadata = new System.Collections.Concurrent.ConcurrentDictionary<string, TypeMetadata>();
+        const string relationshipMetadataFileName = "relationship-metadata.json";
+        var relationshipMetadataFilePath = Path.Combine(metadataDir, relationshipMetadataFileName);
+        var relationshipMetadata = LoadRelationshipMetadata(relationshipMetadataFilePath);
+
         if (Directory.Exists(metadataDir))
         {
             foreach (var file in Directory.GetFiles(metadataDir, "*.json"))
             {
                 var fileName = Path.GetFileNameWithoutExtension(file);
+                if (string.Equals(fileName, relationshipMetadataFileName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 if (!TryDecodeMetadataFileName(fileName, out var fullName))
                     continue;
 
@@ -225,6 +232,30 @@ public static class DomainModelEndpointExtensions
                     continue;
 
                 metadata[fullName] = entry;
+            }
+        }
+
+        static JsonSerializerOptions RelationshipMetadataJsonOptions() => new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        static RelationshipMetadataDocument LoadRelationshipMetadata(string path)
+        {
+            if (!File.Exists(path))
+                return new RelationshipMetadataDocument();
+
+            try
+            {
+                var text = File.ReadAllText(path);
+                var doc = JsonSerializer.Deserialize<RelationshipMetadataDocument>(text, RelationshipMetadataJsonOptions());
+                return doc ?? new RelationshipMetadataDocument();
+            }
+            catch (JsonException)
+            {
+                return new RelationshipMetadataDocument();
             }
         }
 
@@ -244,6 +275,60 @@ public static class DomainModelEndpointExtensions
             }))
             .ExcludeFromDescription()
             .WithName("DomainModelMetadata");
+
+        // GET /domain-model/relationship-metadata — per-edge notes, hide-on-diagram, optional label override
+        endpoints.MapGet($"{routePrefix}/relationship-metadata", () =>
+            Results.Json(relationshipMetadata, RelationshipMetadataJsonOptions()))
+            .ExcludeFromDescription()
+            .WithName("DomainModelRelationshipMetadata");
+
+        // PUT /domain-model/relationship-metadata — replace entire relationship metadata document
+        endpoints.MapPut($"{routePrefix}/relationship-metadata", async (HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            RelationshipMetadataDocument? doc;
+            try
+            {
+                doc = JsonSerializer.Deserialize<RelationshipMetadataDocument>(body, RelationshipMetadataJsonOptions());
+            }
+            catch (JsonException)
+            {
+                return Results.BadRequest("Invalid JSON");
+            }
+
+            if (doc is null)
+                return Results.BadRequest("Invalid document");
+
+            doc.Edges ??= new Dictionary<string, RelationshipEdgeMetadata>(StringComparer.Ordinal);
+
+            // Prune empty entries
+            var cleaned = new Dictionary<string, RelationshipEdgeMetadata>(StringComparer.Ordinal);
+            foreach (var (key, edge) in doc.Edges)
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                    continue;
+
+                var hasDesc = !string.IsNullOrWhiteSpace(edge.Description);
+                var hasHidden = edge.HiddenOnDiagram == true;
+                var hasOverride = !string.IsNullOrWhiteSpace(edge.LabelOverride);
+                if (!hasDesc && !hasHidden && !hasOverride)
+                    continue;
+
+                cleaned[key] = edge;
+            }
+
+            doc.Edges = cleaned;
+            relationshipMetadata.Edges = cleaned;
+
+            Directory.CreateDirectory(metadataDir);
+            var toWrite = JsonSerializer.Serialize(doc, RelationshipMetadataJsonOptions());
+            await File.WriteAllTextAsync(relationshipMetadataFilePath, toWrite);
+
+            return Results.Ok(new { saved = true });
+        })
+        .ExcludeFromDescription()
+        .WithName("DomainModelRelationshipMetadataPut");
 
         // GET /domain-model/exports — list available exports
         if (options.Exports.Count > 0)

--- a/DomainModeling.AspNetCore/RelationshipMetadataModels.cs
+++ b/DomainModeling.AspNetCore/RelationshipMetadataModels.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace DomainModeling.AspNetCore;
+
+/// <summary>
+/// Disk-backed overrides and notes for individual relationship edges on diagrams.
+/// Stored as <c>relationship-metadata.json</c> under <see cref="DomainModelOptions.MetadataStoragePath"/>.
+/// Keys match the diagram convention: <c>sourceFullName|targetFullName|RelationshipKind</c>.
+/// </summary>
+internal sealed class RelationshipMetadataDocument
+{
+    [JsonPropertyName("edges")]
+    public Dictionary<string, RelationshipEdgeMetadata> Edges { get; set; } =
+        new Dictionary<string, RelationshipEdgeMetadata>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// User-editable metadata for one directed relationship edge.
+/// </summary>
+internal sealed class RelationshipEdgeMetadata
+{
+    /// <summary>Optional free-form description shown in edge inspector panels.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>When true, the edge is not drawn on the main diagram (per-edge hide).</summary>
+    [JsonPropertyName("hiddenOnDiagram")]
+    public bool? HiddenOnDiagram { get; set; }
+
+    /// <summary>
+    /// Replaces the short text drawn on the edge (scanner label / kind name).
+    /// Does not change the underlying domain <see cref="Graph.Relationship.Label"/>.
+    /// </summary>
+    [JsonPropertyName("labelOverride")]
+    public string? LabelOverride { get; set; }
+}

--- a/DomainModeling.AspNetCore/wwwroot/css/diagram.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/diagram.css
@@ -7,6 +7,140 @@
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
+
+/* Floating panel: edit relationship link (description, label override, hide on diagram) */
+.diagram-rel-panel {
+  position: absolute;
+  top: 52px;
+  right: 12px;
+  width: min(320px, calc(100% - 24px));
+  max-height: calc(100% - 140px);
+  overflow-y: auto;
+  z-index: 25;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+}
+.diagram-rel-panel-inner {
+  padding: 12px 14px 14px;
+  font-size: 12px;
+}
+.diagram-rel-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.diagram-rel-panel-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.diagram-rel-panel-close {
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+.diagram-rel-panel-close:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.diagram-rel-panel-row {
+  margin-bottom: 6px;
+  color: var(--text);
+}
+.diagram-rel-panel-row.muted {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.diagram-rel-panel-row.small {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+.diagram-rel-panel-row.small code {
+  font-size: 10px;
+}
+.diagram-rel-panel-k {
+  font-weight: 600;
+  color: var(--accent);
+}
+.diagram-rel-panel-label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  margin: 10px 0 4px;
+}
+.diagram-rel-panel-textarea,
+.diagram-rel-panel-input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 8px 10px;
+}
+.diagram-rel-panel-textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+.diagram-rel-panel-hint {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin: 4px 0 0;
+  line-height: 1.35;
+}
+.diagram-rel-panel-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.diagram-rel-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+.diagram-rel-panel-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-hover);
+  color: var(--text-muted);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  font-size: 11px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.diagram-rel-panel-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}
+.diagram-rel-panel-btn.primary {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.diagram-rel-panel-btn.primary:hover {
+  filter: brightness(1.05);
+}
 .diagram-wrap svg { width: 100%; height: 100%; cursor: grab; }
 .diagram-wrap svg.dragging { cursor: grabbing; }
 .diagram-wrap svg.dragging-node { cursor: grabbing; }

--- a/DomainModeling.AspNetCore/wwwroot/css/feature-editor.css
+++ b/DomainModeling.AspNetCore/wwwroot/css/feature-editor.css
@@ -440,6 +440,40 @@
   padding: 3px 0;
 }
 
+.fe-rel-hidden-badge {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-left: 2px;
+}
+
+.fe-panel-pre {
+  white-space: pre-wrap;
+}
+
+.fe-panel-inline-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 500;
+}
+
+.fe-panel-actions-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.fe-panel-actions-row .fe-btn {
+  width: 100%;
+  justify-content: center;
+}
+
 .fe-panel-prop {
   font-size: 12px;
   padding: 2px 0;

--- a/DomainModeling.AspNetCore/wwwroot/js/diagram.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/diagram.js
@@ -400,12 +400,137 @@ function saveEdgeWaypoints(edgeWaypoints) {
   scheduleFlushDiagramLayout();
 }
 
-function edgeKey(e) {
+export function relationshipEdgeKey(e) {
   return `${e.source}|${e.target}|${e.kind}`;
+}
+
+function edgeKey(e) {
+  return relationshipEdgeKey(e);
+}
+
+/** @param {Record<string, any>|null|undefined} edgesMap */
+export function relationshipMetaEntryForEdge(e, edgesMap) {
+  if (!edgesMap || typeof edgesMap !== 'object') return null;
+  let m = edgesMap[edgeKey(e)];
+  if (m) return m;
+  // Merge scanner duplicates that share the same endpoints and kind
+  for (const k of Object.keys(edgesMap)) {
+    const parts = k.split('|');
+    if (parts.length < 3) continue;
+    const kind = parts[parts.length - 1];
+    const target = parts[parts.length - 2];
+    const source = parts.slice(0, -2).join('|');
+    if (source === e.source && target === e.target && kind === e.kind) {
+      return edgesMap[k];
+    }
+  }
+  return null;
+}
+
+/** @param {any[]} edges @param {{ edges?: Record<string, any> }|null|undefined} doc */
+export function applyRelationshipMetadataToEdges(edges, doc) {
+  const map = doc && doc.edges && typeof doc.edges === 'object' ? doc.edges : {};
+  for (const e of edges) {
+    const entry = relationshipMetaEntryForEdge(e, map);
+    e.relDescription = entry && entry.description ? String(entry.description) : '';
+    e.relLabelOverride = entry && entry.labelOverride ? String(entry.labelOverride) : '';
+    e.relHiddenOnDiagram = entry && entry.hiddenOnDiagram === true;
+  }
+}
+
+function diagramEdgeDisplayLabel(e) {
+  const ov = e.relLabelOverride && String(e.relLabelOverride).trim();
+  if (ov) return ov;
+  const base = e.label && String(e.label).trim();
+  return base || e.kind;
+}
+
+/** @type {{ edges: Record<string, any> }} */
+export function emptyRelationshipMetadataDoc() {
+  return { edges: {} };
+}
+
+/** Apply `window.__relationshipMetadata` to the given edge objects (mutates). */
+export function mergeWindowRelationshipMetadataIntoEdges(edges) {
+  const w = typeof window !== 'undefined' && window.__relationshipMetadata;
+  const doc = w && typeof w === 'object' && !Array.isArray(w) ? w : emptyRelationshipMetadataDoc();
+  if (!doc.edges || typeof doc.edges !== 'object') doc.edges = {};
+  applyRelationshipMetadataToEdges(edges, doc);
+}
+
+/**
+ * Merge relationship metadata from `window.__relationshipMetadata` into `dgState.allEdges`
+ * and refresh the visible edge list.
+ */
+export function reapplyRelationshipMetadataFromWindow() {
+  if (!dgState) return;
+  const w = typeof window !== 'undefined' && window.__relationshipMetadata;
+  dgState.relationshipMetadata = w && typeof w === 'object' && !Array.isArray(w)
+    ? w
+    : emptyRelationshipMetadataDoc();
+  if (!dgState.relationshipMetadata.edges || typeof dgState.relationshipMetadata.edges !== 'object') {
+    dgState.relationshipMetadata.edges = {};
+  }
+  applyRelationshipMetadataToEdges(dgState.allEdges, dgState.relationshipMetadata);
+  applyDiagramVisibility();
+  renderSvg();
+  refreshDiagramRelPanel();
+}
+
+let relationshipMetaFlushTimer = null;
+export function scheduleFlushRelationshipMetadata() {
+  if (!diagramLayoutBaseUrl) return;
+  if (relationshipMetaFlushTimer) clearTimeout(relationshipMetaFlushTimer);
+  relationshipMetaFlushTimer = setTimeout(() => {
+    relationshipMetaFlushTimer = null;
+    void flushRelationshipMetadataToServer();
+  }, FLUSH_MS);
+}
+
+async function flushRelationshipMetadataToServer() {
+  if (!diagramLayoutBaseUrl) return;
+  const doc = (typeof window !== 'undefined' && window.__relationshipMetadata) || emptyRelationshipMetadataDoc();
+  try {
+    const res = await fetch(`${diagramLayoutBaseUrl}/relationship-metadata`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(doc),
+    });
+    if (!res.ok) return;
+  } catch { /* ignore */ }
+}
+
+/**
+ * Update one edge's metadata (description, hide on main diagram, optional label override).
+ * Persists the full document to disk when the API base URL is configured.
+ */
+export async function persistRelationshipEdgeMetadata(edgeKey, patch) {
+  const doc = (typeof window !== 'undefined' && window.__relationshipMetadata) || emptyRelationshipMetadataDoc();
+  if (!doc.edges || typeof doc.edges !== 'object') doc.edges = {};
+
+  const desc = patch && patch.description != null ? String(patch.description).trim() : '';
+  const labelOv = patch && patch.labelOverride != null ? String(patch.labelOverride).trim() : '';
+  const hidden = patch && patch.hiddenOnDiagram === true;
+
+  if (!desc && !labelOv && !hidden) {
+    delete doc.edges[edgeKey];
+  } else {
+    doc.edges[edgeKey] = {
+      ...(hidden ? { hiddenOnDiagram: true } : {}),
+      ...(desc ? { description: desc } : {}),
+      ...(labelOv ? { labelOverride: labelOv } : {}),
+    };
+  }
+
+  if (typeof window !== 'undefined') window.__relationshipMetadata = doc;
+  reapplyRelationshipMetadataFromWindow();
+  scheduleFlushRelationshipMetadata();
 }
 
 // ── Module state ─────────────────────────────────────
 let dgState = null;
+/** @type {string|null} */
+let dgSelectedEdgeKey = null;
 
 /** @type {Set<string>} */
 let traceHighlightIds = new Set();
@@ -575,6 +700,7 @@ export function renderDiagramView(opts = {}) {
   html += '</div>';
 
   html += '<svg id="diagramSvg"></svg>';
+  html += '<div id="diagramRelPanel" class="diagram-rel-panel" style="display:none"></div>';
   html += '</div>';
   return html;
 }
@@ -584,6 +710,7 @@ export function initDiagram(ctx, boundedContexts) {
   if (!ctx) return;
 
   migrateLegacyDiagramLocalStorage();
+  dgSelectedEdgeKey = null;
 
   const nodes = [];
   const edges = [];
@@ -647,6 +774,12 @@ export function initDiagram(ctx, boundedContexts) {
       edges.push({ source: rel.sourceType, target: rel.targetType, kind: rel.kind, label: rel.label || '' });
     }
   }
+
+  const relMeta = (typeof window !== 'undefined' && window.__relationshipMetadata && typeof window.__relationshipMetadata === 'object' && !Array.isArray(window.__relationshipMetadata))
+    ? window.__relationshipMetadata
+    : emptyRelationshipMetadataDoc();
+  if (!relMeta.edges || typeof relMeta.edges !== 'object') relMeta.edges = {};
+  applyRelationshipMetadataToEdges(edges, relMeta);
 
   const contextName = ctx.name;
   let posSource = 'none';
@@ -730,6 +863,7 @@ export function initDiagram(ctx, boundedContexts) {
       nodes, edges, nMap, allNodes: nodes, allEdges: edges,
       zoom: 1, panX: 0, panY: 0, contextName,
       hiddenKinds, hiddenNodeIds, hiddenEdgeKinds, edgeWaypoints,
+      relationshipMetadata: relMeta,
     };
     applyDiagramVisibility();
 
@@ -929,8 +1063,12 @@ function applyDiagramVisibility() {
     return true;
   });
   dgState.edges = dgState.allEdges.filter(e =>
-    visibleIds.has(e.source) && visibleIds.has(e.target) && !dgState.hiddenEdgeKinds.has(e.kind)
+    visibleIds.has(e.source) && visibleIds.has(e.target) && !dgState.hiddenEdgeKinds.has(e.kind) && !e.relHiddenOnDiagram
   );
+  if (dgSelectedEdgeKey && !dgState.edges.some(e => edgeKey(e) === dgSelectedEdgeKey)) {
+    dgSelectedEdgeKey = null;
+    refreshDiagramRelPanel();
+  }
 }
 
 // ── Auto-layout (row-based + forces) ─────────────────
@@ -1136,6 +1274,9 @@ function renderSvg() {
     const markerEnd = (e.kind === 'References' || e.kind === 'ReferencesById') ? '' : ` marker-end="url(#arrow-${e.kind})"`;
 
     const ek = edgeKey(e);
+    const edgeSelected = dgSelectedEdgeKey === ek;
+    const sw = edgeSelected ? 3 : 1.5;
+    const op = edgeSelected ? 1 : 0.65;
     const waypoints = (dgState.edgeWaypoints && dgState.edgeWaypoints[ek]) || [];
 
     if (waypoints.length === 0) {
@@ -1143,9 +1284,9 @@ function renderSvg() {
       const p2 = rectEdge(tgtCx, tgtCy, tgt.w + 8, tgt.h + 8, srcCx, srcCy);
       // Invisible hit area for double-click to add waypoints
       s += `<line class="dg-edge-hit" data-edge-key="${escAttr(ek)}" x1="${p1.x}" y1="${p1.y}" x2="${p2.x}" y2="${p2.y}" stroke="transparent" stroke-width="12" fill="none" style="cursor:pointer" />`;
-      s += `<line x1="${p1.x}" y1="${p1.y}" x2="${p2.x}" y2="${p2.y}" stroke="${color}" stroke-width="1.5"${dashed}${markerStart}${markerEnd} opacity="0.65" pointer-events="none" />`;
+      s += `<line x1="${p1.x}" y1="${p1.y}" x2="${p2.x}" y2="${p2.y}" stroke="${color}" stroke-width="${sw}"${dashed}${markerStart}${markerEnd} opacity="${op}" pointer-events="none" />`;
       const mx = (p1.x + p2.x) / 2, my = (p1.y + p2.y) / 2;
-      const label = e.label || e.kind;
+      const label = diagramEdgeDisplayLabel(e);
       s += `<text x="${mx}" y="${my - 6}" text-anchor="middle" fill="${color}" font-size="9" font-family="-apple-system,sans-serif" opacity="0.7" pointer-events="none">${esc(label)}</text>`;
     } else {
       const firstWp = waypoints[0];
@@ -1162,14 +1303,14 @@ function renderSvg() {
       }
       // Invisible hit area
       s += `<path class="dg-edge-hit" data-edge-key="${escAttr(ek)}" d="${pathD}" stroke="transparent" stroke-width="12" fill="none" style="cursor:pointer" />`;
-      s += `<path d="${pathD}" stroke="${color}" stroke-width="1.5"${dashed}${markerStart}${markerEnd} opacity="0.65" fill="none" pointer-events="none" />`;
+      s += `<path d="${pathD}" stroke="${color}" stroke-width="${sw}"${dashed}${markerStart}${markerEnd} opacity="${op}" fill="none" pointer-events="none" />`;
 
       // Label at midpoint of entire path
       const midIdx = Math.floor(allPts.length / 2);
       const mPrev = allPts[midIdx - 1] || allPts[0];
       const mNext = allPts[midIdx] || allPts[allPts.length - 1];
       const mx = (mPrev.x + mNext.x) / 2, my = (mPrev.y + mNext.y) / 2;
-      const label = e.label || e.kind;
+      const label = diagramEdgeDisplayLabel(e);
       s += `<text x="${mx}" y="${my - 6}" text-anchor="middle" fill="${color}" font-size="9" font-family="-apple-system,sans-serif" opacity="0.7" pointer-events="none">${esc(label)}</text>`;
 
       // Waypoint handles
@@ -1272,10 +1413,14 @@ function setupInteraction() {
     if (wpEl) {
       ev.preventDefault();
       ev.stopPropagation();
+      dgSelectedEdgeKey = null;
+      refreshDiagramRelPanel();
       dragWp = { edgeKey: wpEl.dataset.edgeKey, wpIdx: parseInt(wpEl.dataset.wpIdx, 10) };
       svg.classList.add('dragging-node');
     } else if (nodeEl) {
       ev.preventDefault();
+      dgSelectedEdgeKey = null;
+      refreshDiagramRelPanel();
       const n = dgState.nMap[nodeEl.dataset.id];
       if (!n) return;
       dragNode = n;
@@ -1284,6 +1429,8 @@ function setupInteraction() {
       svg.classList.add('dragging-node');
     } else if (ctxEl) {
       ev.preventDefault();
+      dgSelectedEdgeKey = null;
+      refreshDiagramRelPanel();
       const ctxName = ctxEl.dataset.ctx;
       dragCtx = ctxName;
       const pt = svgPoint(svg, ev);
@@ -1296,6 +1443,16 @@ function setupInteraction() {
       }
       svg.classList.add('dragging-node');
     } else {
+      const edgeHit = ev.target.closest('.dg-edge-hit');
+      if (edgeHit && edgeHit.dataset.edgeKey) {
+        ev.preventDefault();
+        dgSelectedEdgeKey = edgeHit.dataset.edgeKey;
+        renderSvg();
+        refreshDiagramRelPanel();
+        return;
+      }
+      dgSelectedEdgeKey = null;
+      refreshDiagramRelPanel();
       panning = true;
       panStartX = ev.clientX; panStartY = ev.clientY;
       panOrigX = dgState.panX; panOrigY = dgState.panY;
@@ -1487,6 +1644,8 @@ export function diagramResetLayout(ctx) {
   saveHiddenNodeIds(dgState.hiddenNodeIds);
   dgState.edgeWaypoints = {};
   saveEdgeWaypoints(dgState.edgeWaypoints);
+  dgSelectedEdgeKey = null;
+  refreshDiagramRelPanel();
   applyAutoLayout(dgState.allNodes, dgState.allEdges, dgState.nMap);
   applyDiagramVisibility();
   renderSvg();
@@ -1663,4 +1822,77 @@ function diagramDisplayName(n) {
   const meta = window.__metadata || {};
   const entry = meta[n.id];
   return (entry && entry.alias && entry.alias.trim()) ? entry.alias : n.name;
+}
+
+function refreshDiagramRelPanel() {
+  const panel = document.getElementById('diagramRelPanel');
+  if (!panel) return;
+  if (!dgState || !dgSelectedEdgeKey) {
+    panel.style.display = 'none';
+    panel.innerHTML = '';
+    return;
+  }
+  const e = dgState.allEdges.find(edge => edgeKey(edge) === dgSelectedEdgeKey);
+  if (!e) {
+    panel.style.display = 'none';
+    panel.innerHTML = '';
+    dgSelectedEdgeKey = null;
+    return;
+  }
+  const entry = relationshipMetaEntryForEdge(e, dgState.relationshipMetadata?.edges);
+  const desc = (entry && entry.description) ? String(entry.description) : '';
+  const labelOv = (entry && entry.labelOverride) ? String(entry.labelOverride) : '';
+  const hidden = entry && entry.hiddenOnDiagram === true;
+  const scannerLabel = e.label && String(e.label).trim() ? String(e.label) : e.kind;
+
+  let h = '<div class="diagram-rel-panel-inner">';
+  h += '<div class="diagram-rel-panel-header">';
+  h += '<span class="diagram-rel-panel-title">Relationship</span>';
+  h += `<button type="button" class="diagram-rel-panel-close" onclick="window.__diagram.clearEdgeSelection()" title="Close">✕</button>`;
+  h += '</div>';
+  h += `<div class="diagram-rel-panel-row"><span class="diagram-rel-panel-k">${esc(e.kind)}</span></div>`;
+  h += `<div class="diagram-rel-panel-row muted">${esc(shortName(e.source))} → ${esc(shortName(e.target))}</div>`;
+  h += `<div class="diagram-rel-panel-row small">Scanner label: <code>${esc(scannerLabel)}</code></div>`;
+
+  h += '<label class="diagram-rel-panel-label">Description</label>';
+  h += `<textarea class="diagram-rel-panel-textarea" rows="3" id="dgRelDescInput" placeholder="Notes for this link…">${esc(desc)}</textarea>`;
+
+  h += '<label class="diagram-rel-panel-label">Label on diagram (optional)</label>';
+  h += `<input type="text" class="diagram-rel-panel-input" id="dgRelLabelInput" value="${escAttr(labelOv)}" placeholder="Leave empty to use scanner label / kind" />`;
+  h += '<div class="diagram-rel-panel-hint">Overrides the short text drawn on the edge. Does not change the underlying domain model.</div>';
+
+  h += '<label class="diagram-rel-panel-check">';
+  h += `<input type="checkbox" id="dgRelHideInput"${hidden ? ' checked' : ''} />`;
+  h += 'Hide this link on the main diagram</label>';
+
+  h += '<div class="diagram-rel-panel-actions">';
+  h += `<button type="button" class="diagram-rel-panel-btn primary" onclick="window.__diagram.applyEdgeMetadataEdits()">Apply</button>`;
+  h += `<button type="button" class="diagram-rel-panel-btn" onclick="window.__diagram.clearEdgeMetadata()">Clear overrides</button>`;
+  h += '</div>';
+  h += '</div>';
+
+  panel.innerHTML = h;
+  panel.style.display = 'block';
+}
+
+export function clearEdgeSelection() {
+  dgSelectedEdgeKey = null;
+  if (dgState) renderSvg();
+  refreshDiagramRelPanel();
+}
+
+export function applyEdgeMetadataEdits() {
+  if (!dgSelectedEdgeKey) return;
+  const descEl = document.getElementById('dgRelDescInput');
+  const labelEl = document.getElementById('dgRelLabelInput');
+  const hideEl = document.getElementById('dgRelHideInput');
+  const desc = descEl ? descEl.value : '';
+  const labelOverride = labelEl ? labelEl.value : '';
+  const hiddenOnDiagram = hideEl ? hideEl.checked : false;
+  void persistRelationshipEdgeMetadata(dgSelectedEdgeKey, { description: desc, labelOverride, hiddenOnDiagram });
+}
+
+export function clearEdgeMetadata() {
+  if (!dgSelectedEdgeKey) return;
+  void persistRelationshipEdgeMetadata(dgSelectedEdgeKey, { description: '', labelOverride: '', hiddenOnDiagram: false });
 }

--- a/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/feature-editor.js
@@ -26,6 +26,11 @@ import {
   diagramToggleAliases,
   diagramToggleLayers,
   syncDiagramToolbarToggles,
+  relationshipEdgeKey,
+  relationshipMetaEntryForEdge,
+  mergeWindowRelationshipMetadataIntoEdges,
+  persistRelationshipEdgeMetadata,
+  scheduleFlushRelationshipMetadata,
 } from './diagram.js';
 
 // ── Constants ────────────────────────────────────────
@@ -159,6 +164,44 @@ try {
   viewModeOnly = sessionStorage.getItem(FEATURE_EDITOR_VIEW_MODE_KEY) === '1';
 } catch { viewModeOnly = false; }
 
+function feApplyRelationshipMetaToEdges() {
+  if (!st) return;
+  mergeWindowRelationshipMetadataIntoEdges(st.edges);
+}
+
+function feEdgeDisplayLabel(e) {
+  const ov = e.relLabelOverride && String(e.relLabelOverride).trim();
+  if (ov) return ov;
+  const base = e.label && String(e.label).trim();
+  return base || e.kind;
+}
+
+/** Rewire relationship-metadata keys when a node id changes (e.g. custom type rename). */
+function feMigrateRelationshipMetadataKeys(oldId, newId) {
+  const doc = typeof window !== 'undefined' ? window.__relationshipMetadata : null;
+  if (!doc || typeof doc !== 'object') return;
+  if (!doc.edges || typeof doc.edges !== 'object') doc.edges = {};
+  const entries = Object.entries(doc.edges);
+  let changed = false;
+  for (const [key, val] of entries) {
+    const parts = key.split('|');
+    if (parts.length < 3) continue;
+    const kind = parts[parts.length - 1];
+    const target = parts[parts.length - 2];
+    const source = parts.slice(0, -2).join('|');
+    let s = source;
+    let t = target;
+    if (s === oldId) s = newId;
+    if (t === oldId) t = newId;
+    if (s === source && t === target) continue;
+    const nk = `${s}|${t}|${kind}`;
+    delete doc.edges[key];
+    doc.edges[nk] = val;
+    changed = true;
+  }
+  if (changed) scheduleFlushRelationshipMetadata();
+}
+
 function isViewModeOnly() {
   return viewModeOnly === true;
 }
@@ -268,6 +311,13 @@ function feDomainMethodsToStructured(methods) {
 export async function initFeatureEditor(apiBaseUrl, data) {
   baseUrl = apiBaseUrl;
   domainData = data;
+  try {
+    const res = await fetch(`${baseUrl}/relationship-metadata`);
+    if (res.ok) {
+      const doc = await res.json();
+      if (typeof window !== 'undefined') window.__relationshipMetadata = doc;
+    }
+  } catch { /* optional */ }
   await loadFeatureList();
   await loadFeatureExports();
 }
@@ -872,7 +922,8 @@ function renderPropertiesPanel() {
       for (const e of rels) {
         const other = e.source === n.id ? shortName(e.target) : shortName(e.source);
         const dir = e.source === n.id ? '→' : '←';
-        h += `<div class="fe-panel-rel">${dir} <span style="color:${EDGE_COLORS[e.kind] || '#888'}">${e.kind}</span> ${esc(other)}</div>`;
+        const hid = e.relHiddenOnDiagram ? ' <span class="fe-rel-hidden-badge" title="Hidden on main diagram">⊘</span>' : '';
+        h += `<div class="fe-panel-rel">${dir} <span style="color:${EDGE_COLORS[e.kind] || '#888'}">${e.kind}</span> ${esc(other)}${hid}</div>`;
       }
     }
 
@@ -890,6 +941,12 @@ function renderPropertiesPanel() {
     const e = st.edges[st.selectedEdge];
     if (!e) return renderPanelInstructions();
 
+    const metaMap = (typeof window !== 'undefined' && window.__relationshipMetadata?.edges) || {};
+    const entry = relationshipMetaEntryForEdge(e, metaMap);
+    const desc = (entry && entry.description) ? String(entry.description) : '';
+    const labelOv = (entry && entry.labelOverride) ? String(entry.labelOverride) : '';
+    const hiddenMain = entry && entry.hiddenOnDiagram === true;
+
     let h = `<div class="fe-panel-title" style="color:${EDGE_COLORS[e.kind] || '#888'}">Relationship</div>`;
     h += `<div class="fe-panel-field"><label>Source</label><div class="fe-panel-value">${esc(shortName(e.source))}</div></div>`;
     h += `<div class="fe-panel-field"><label>Target</label><div class="fe-panel-value">${esc(shortName(e.target))}</div></div>`;
@@ -898,7 +955,31 @@ function renderPropertiesPanel() {
       ? `<div class="fe-panel-value">${esc(e.kind)}</div>`
       : renderRelKindDropdown(e.kind, st.selectedEdge);
     h += '</div>';
-    if (e.label) h += `<div class="fe-panel-field"><label>Label</label><div class="fe-panel-value">${esc(e.label)}</div></div>`;
+    if (e.label) h += `<div class="fe-panel-field"><label>Scanner label</label><div class="fe-panel-value">${esc(e.label)}</div></div>`;
+    h += '<div class="fe-panel-section">Link notes (saved globally)</div>';
+    h += `<div class="fe-panel-field"><label>Description</label>`;
+    h += readOnly
+      ? `<div class="fe-panel-value fe-panel-pre">${desc ? esc(desc) : '—'}</div>`
+      : `<textarea class="fe-input" rows="3" id="feRelDescInput" placeholder="Describe this relationship…">${esc(desc)}</textarea>`;
+    h += '</div>';
+    h += `<div class="fe-panel-field"><label>Label on diagrams</label>`;
+    h += readOnly
+      ? `<div class="fe-panel-value">${labelOv ? esc(labelOv) : '—'}</div>`
+      : `<input type="text" class="fe-input" id="feRelLabelInput" value="${escAttr(labelOv)}" placeholder="Optional; overrides short edge text" />`;
+    h += '</div>';
+    h += `<div class="fe-panel-field"><label>Main diagram</label>`;
+    if (readOnly) {
+      h += `<div class="fe-panel-value">${hiddenMain ? 'Hidden' : 'Visible'}</div>`;
+    } else {
+      h += `<label class="fe-panel-inline-check"><input type="checkbox" id="feRelHideInput"${hiddenMain ? ' checked' : ''} /> Hide this link on the main diagram</label>`;
+    }
+    h += '</div>';
+    if (!readOnly) {
+      h += '<div class="fe-panel-actions-row">';
+      h += `<button type="button" class="fe-btn primary" onclick="window.__featureEditor.applyFeEdgeRelationshipMetadata()">Apply link settings</button>`;
+      h += `<button type="button" class="fe-btn" onclick="window.__featureEditor.clearFeEdgeRelationshipMetadata()">Clear link settings</button>`;
+      h += '</div>';
+    }
     if (!readOnly) {
       h += '<div class="fe-panel-section">Actions</div>';
       h += `<button class="fe-btn danger" onclick="window.__featureEditor.removeEdge(${st.selectedEdge})">✕ Remove Relation</button>`;
@@ -938,6 +1019,7 @@ function getEmittedEventsForNode(nodeId) {
       if (e.source !== nodeId || e.kind !== 'Emits') return false;
       if (!isViewModeOnly()) return true;
       if (st.hiddenEdgeKinds.has('Emits')) return false;
+      if (e.relHiddenOnDiagram) return false;
       const tgt = st.nMap[e.target];
       if (!tgt || st.hiddenKinds.has(tgt.kind)) return false;
       return true;
@@ -1274,6 +1356,7 @@ function loadFeatureState(feature) {
       st.edges.push({ source: saved.source, target: saved.target, kind: saved.kind, label: saved.label || '' });
     }
   }
+  feApplyRelationshipMetaToEdges();
 
   const fixedFromSaved = new Set();
   for (const n of st.nodes) {
@@ -1538,6 +1621,7 @@ function finishConnect(targetId) {
   // Show kind picker overlay
   showRelationKindPicker((kind) => {
     st.edges.push({ source: sourceId, target: targetId, kind, label: '' });
+    feApplyRelationshipMetaToEdges();
     recalcNodeHeights();
     markDirty();
     renderSvg();
@@ -1684,6 +1768,8 @@ export function renameCustomType(nodeId, newShortName) {
     if (e.source === nodeId) e.source = newId;
     if (e.target === nodeId) e.target = newId;
   }
+  feMigrateRelationshipMetadataKeys(nodeId, newId);
+  feApplyRelationshipMetaToEdges();
   if (connecting && connecting.sourceId === nodeId) connecting.sourceId = newId;
   if (st.selectedNode === nodeId) st.selectedNode = newId;
 
@@ -1797,7 +1883,17 @@ function toggleDropdownById(menuId, wrapperId) {
 export function removeEdge(idx) {
   if (isReadOnlyFeature()) return;
   if (!st) return;
+  const removed = st.edges[idx];
+  if (removed && typeof window !== 'undefined' && window.__relationshipMetadata) {
+    if (!window.__relationshipMetadata.edges || typeof window.__relationshipMetadata.edges !== 'object') {
+      window.__relationshipMetadata.edges = {};
+    }
+    const k = relationshipEdgeKey(removed);
+    delete window.__relationshipMetadata.edges[k];
+    scheduleFlushRelationshipMetadata();
+  }
   st.edges.splice(idx, 1);
+  feApplyRelationshipMetaToEdges();
   st.selectedEdge = null;
   recalcNodeHeights();
   markDirty();
@@ -1809,11 +1905,53 @@ export function removeEdge(idx) {
 export function changeEdgeKind(idx, kind) {
   if (isReadOnlyFeature()) return;
   if (!st || !st.edges[idx]) return;
-  st.edges[idx].kind = kind;
+  const e = st.edges[idx];
+  const oldKey = relationshipEdgeKey(e);
+  e.kind = kind;
+  const newKey = relationshipEdgeKey(e);
+  if (oldKey !== newKey && typeof window !== 'undefined' && window.__relationshipMetadata) {
+    const doc = window.__relationshipMetadata;
+    if (!doc.edges || typeof doc.edges !== 'object') doc.edges = {};
+    if (doc.edges[oldKey]) {
+      doc.edges[newKey] = doc.edges[oldKey];
+      delete doc.edges[oldKey];
+      scheduleFlushRelationshipMetadata();
+    }
+  }
+  feApplyRelationshipMetaToEdges();
   recalcNodeHeights();
   markDirty();
   renderSvg();
   if (isViewModeOnly()) refreshFeViewFilters();
+}
+
+/** Persist description / label override / hide-on-main-diagram for the selected feature edge (global store). */
+export function applyFeEdgeRelationshipMetadata() {
+  if (!st || st.selectedEdge === null) return;
+  const e = st.edges[st.selectedEdge];
+  if (!e) return;
+  const descEl = document.getElementById('feRelDescInput');
+  const labelEl = document.getElementById('feRelLabelInput');
+  const hideEl = document.getElementById('feRelHideInput');
+  const desc = descEl ? descEl.value : '';
+  const labelOverride = labelEl ? labelEl.value : '';
+  const hiddenOnDiagram = hideEl ? hideEl.checked : false;
+  void persistRelationshipEdgeMetadata(relationshipEdgeKey(e), { description: desc, labelOverride, hiddenOnDiagram });
+  feApplyRelationshipMetaToEdges();
+  markDirty();
+  renderSvg();
+  refreshPanel();
+}
+
+export function clearFeEdgeRelationshipMetadata() {
+  if (!st || st.selectedEdge === null) return;
+  const e = st.edges[st.selectedEdge];
+  if (!e) return;
+  void persistRelationshipEdgeMetadata(relationshipEdgeKey(e), { description: '', labelOverride: '', hiddenOnDiagram: false });
+  feApplyRelationshipMetaToEdges();
+  markDirty();
+  renderSvg();
+  refreshPanel();
 }
 
 /** Recalculate all node heights (needed when edges change since Emits affects height). */
@@ -1838,6 +1976,7 @@ function importAllRelationshipsFromDomain() {
       st.edges.push({ source: rel.sourceType, target: rel.targetType, kind: rel.kind, label: rel.label || '' });
     }
   }
+  feApplyRelationshipMetaToEdges();
 }
 
 function findDomainItem(fullName, kind) {
@@ -2072,6 +2211,7 @@ function renderSvg() {
     if (!src || !tgt) continue;
     if (vm) {
       if (st.hiddenEdgeKinds.has(e.kind)) continue;
+      if (e.relHiddenOnDiagram) continue;
       if (!visibleNodeIds.has(src.id) || !visibleNodeIds.has(tgt.id)) continue;
     }
     const srcCx = src.x + src.w / 2, srcCy = src.y + src.h / 2;
@@ -2091,7 +2231,7 @@ function renderSvg() {
     }
     s += `<line class="fe-edge-vis" data-idx="${ei}" x1="${p1.x}" y1="${p1.y}" x2="${p2.x}" y2="${p2.y}" stroke="${color}" stroke-width="${sw}"${dashed}${markerStart}${markerEnd} opacity="${op}" style="pointer-events:none" />`;
     const mx = (p1.x + p2.x) / 2, my = (p1.y + p2.y) / 2;
-    s += `<text x="${mx}" y="${my - 6}" text-anchor="middle" fill="${color}" font-size="9" font-family="-apple-system,sans-serif" opacity="0.7" style="pointer-events:none">${esc(e.label || e.kind)}</text>`;
+    s += `<text x="${mx}" y="${my - 6}" text-anchor="middle" fill="${color}" font-size="9" font-family="-apple-system,sans-serif" opacity="0.7" style="pointer-events:none">${esc(feEdgeDisplayLabel(e))}</text>`;
   }
 
   // Connection line being drawn

--- a/DomainModeling.AspNetCore/wwwroot/js/main.js
+++ b/DomainModeling.AspNetCore/wwwroot/js/main.js
@@ -8,7 +8,7 @@ import {
   diagramDownloadSvg, diagramToggleAliases, diagramToggleLayers, diagramToggleEdgeKind, diagramToggleEdgeFilter,
   diagramToggleKindFilter, diagramShowAllKinds, diagramHideAllKinds, setDiagramLayoutBaseUrl, setServerDiagramLayoutCache,
   isDiagramNodeHidden, getDiagramState, metadataImpliesDiagramHiddenByDefault, reapplyDiagramVisibilityAfterMetadataChange,
-  removeLegacyHiddenNodeId,
+  removeLegacyHiddenNodeId, clearEdgeSelection, applyEdgeMetadataEdits, clearEdgeMetadata,
 } from './diagram.js';
 
 const API_URL = window.__config?.apiUrl || '/domain-model/json';
@@ -91,6 +91,27 @@ async function init() {
       metadata = legacyMetadata;
     }
     window.__metadata = metadata;
+
+    try {
+      const relRes = await fetch(`${BASE_URL}/relationship-metadata`);
+      if (relRes.ok) {
+        const relDoc = await relRes.json();
+        if (relDoc && typeof relDoc === 'object' && !Array.isArray(relDoc)) {
+          window.__relationshipMetadata = relDoc;
+          if (!window.__relationshipMetadata.edges || typeof window.__relationshipMetadata.edges !== 'object') {
+            window.__relationshipMetadata.edges = {};
+          }
+        } else {
+          window.__relationshipMetadata = { edges: {} };
+        }
+      } else {
+        window.__relationshipMetadata = window.__relationshipMetadata || { edges: {} };
+        if (!window.__relationshipMetadata.edges) window.__relationshipMetadata.edges = {};
+      }
+    } catch {
+      window.__relationshipMetadata = window.__relationshipMetadata || { edges: {} };
+      if (!window.__relationshipMetadata.edges) window.__relationshipMetadata.edges = {};
+    }
 
     setDiagramLayoutBaseUrl(BASE_URL);
     try {
@@ -526,8 +547,15 @@ window.__diagram = {
   toggleKindFilter: diagramToggleKindFilter,
   showAllKinds: diagramShowAllKinds,
   hideAllKinds: diagramHideAllKinds,
+  clearEdgeSelection,
+  applyEdgeMetadataEdits,
+  clearEdgeMetadata,
 };
 window.__metadata = metadata;
+if (!window.__relationshipMetadata || typeof window.__relationshipMetadata !== 'object') {
+  window.__relationshipMetadata = { edges: {} };
+}
+if (!window.__relationshipMetadata.edges) window.__relationshipMetadata.edges = {};
 
 // ── Testing globals (wired after lazy-load) ──────────────
 function wireTestingGlobals() {
@@ -597,6 +625,8 @@ function wireFeatureEditorGlobals() {
     hideAllFeKinds: featureEditorModule.hideAllFeKinds,
     toggleFeEdgeKind: featureEditorModule.toggleFeEdgeKind,
     onDiagramViewFlagsChanged: featureEditorModule.onDiagramViewFlagsChanged,
+    applyFeEdgeRelationshipMetadata: featureEditorModule.applyFeEdgeRelationshipMetadata,
+    clearFeEdgeRelationshipMetadata: featureEditorModule.clearFeEdgeRelationshipMetadata,
   };
 }
 // ── Go! ──────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **per-relationship edge** customization stored on disk as `metadata/relationship-metadata.json` (alongside per-type metadata):

- **Description** (free-form notes)
- **Hide on main diagram** (per edge, in addition to kind filters)
- **Optional label override** for the short text drawn on edges (does not change scanner/domain `Relationship.Label`)

## API

- `GET {routePrefix}/relationship-metadata` — full document
- `PUT {routePrefix}/relationship-metadata` — replace document (edges keyed as `sourceFullName|targetFullName|Kind`)

## UI

- **Diagram tab**: click an edge to open a floating panel; Apply persists; hidden edges disappear from the main diagram.
- **Feature editor**: selecting an edge shows the same fields; **Apply link settings** persists globally. View mode hides edges marked hidden on the main diagram; emitted-events list respects that.

## Notes

- Changing relation **kind** or renaming a **custom** type rewrites metadata keys when applicable.
- Removing an edge clears its metadata entry.

## Tests

`dotnet build` and `dotnet test` (63 tests) pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37baa06e-78b3-419a-a918-e6eb20166486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37baa06e-78b3-419a-a918-e6eb20166486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

